### PR TITLE
feat: settings redesign and in-slideshow playback controls

### DIFF
--- a/app/BigImmich/BigImmichApp.swift
+++ b/app/BigImmich/BigImmichApp.swift
@@ -33,17 +33,14 @@ struct BigImmichApp: App {
     init() {
         Self.applyUITestConfiguration()
 
-        if sentryEnabled {
-            let customSentryDSN = sentryDSN.trimmingCharacters(
-                in: .whitespacesAndNewlines
-            )
-            let usedSentryDSN =
-                customSentryDSN != ""
-                    ? customSentryDSN
-                    : "https://3361208ffd59305f7e5c9d0228940679@o118777.ingest.us.sentry.io/4510570198269952"
-
+        let customSentryDSN = sentryDSN.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        // Error reporting only runs when the user enables it and supplies their own DSN — there
+        // is no built-in fallback DSN.
+        if sentryEnabled, !customSentryDSN.isEmpty {
             SentrySDK.start { options in
-                options.dsn = usedSentryDSN
+                options.dsn = customSentryDSN
 
                 options.enableAutoSessionTracking = false
                 options.tracesSampleRate = 0.0

--- a/app/BigImmich/MainView.swift
+++ b/app/BigImmich/MainView.swift
@@ -22,6 +22,10 @@ struct ContentView: View {
                     }
                 )
                 .zIndex(50)
+            } else if router.selectedTab == .settings {
+                // Settings is its own full-page destination — no top menu. It handles its own
+                // back button (two-stage: detail → sidebar, sidebar → exit).
+                SettingsView(onExit: router.exitSettings)
             } else {
                 VStack {
                     Picker("Menu", selection: $router.selectedTab) {
@@ -98,8 +102,8 @@ struct ContentView: View {
                 )
             }
         case .settings:
-            SettingsView()
-                .onExitCommand(perform: router.exitSettings)
+            // Rendered full-page above, outside the tab chrome.
+            EmptyView()
         }
     }
 }

--- a/app/BigImmich/Settings/RemoteDiagramView.swift
+++ b/app/BigImmich/Settings/RemoteDiagramView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+/// A control on the Siri Remote that the Controls page can describe and highlight. Focusing its row
+/// in the list lights up the matching element on the remote graphic.
+enum RemoteControl: Hashable {
+    case up, down, left, right, back, playPause
+
+    var icon: String {
+        switch self {
+        case .up: "chevron.up"
+        case .down: "chevron.down"
+        case .left: "chevron.left"
+        case .right: "chevron.right"
+        case .back: "chevron.backward"
+        case .playPause: "playpause.fill"
+        }
+    }
+}
+
+/// A stylised Siri Remote graphic for the Controls settings page — a tall remote body with the
+/// click-pad and the two columns of hardware buttons (back / play-pause / mute on the left, TV and
+/// the volume rocker on the right). It fills the height it's given. `highlight` emphasises one
+/// control so it stays in sync with whatever row is focused in the list beside it.
+struct RemoteDiagramView: View {
+    var highlight: RemoteControl?
+
+    var body: some View {
+        VStack(spacing: 44) {
+            clickpad
+            buttonGrid
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 48)
+        .padding(.horizontal, 30)
+        .frame(width: 210)
+        .frame(maxHeight: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 44, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [Color.white.opacity(0.16), Color.white.opacity(0.04)],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 44, style: .continuous)
+                        .stroke(Color.white.opacity(0.14), lineWidth: 1)
+                )
+        )
+        .animation(.easeInOut(duration: 0.15), value: highlight)
+    }
+
+    private var clickpad: some View {
+        ZStack {
+            Circle().fill(Color.black.opacity(0.35))
+            Circle().stroke(Color.white.opacity(0.18), lineWidth: 1)
+
+            VStack {
+                padGlyph(.up)
+                Spacer()
+                padGlyph(.down)
+            }
+            .padding(18)
+
+            HStack {
+                padGlyph(.left)
+                Spacer()
+                padGlyph(.right)
+            }
+            .padding(18)
+
+            Circle().fill(Color.white.opacity(0.06)).frame(width: 58, height: 58)
+        }
+        .frame(width: 142, height: 142)
+        .font(.system(size: 16, weight: .bold))
+    }
+
+    private func padGlyph(_ control: RemoteControl) -> some View {
+        let active = highlight == control
+        return Image(systemName: control.icon)
+            .foregroundColor(active ? .white : .white.opacity(0.5))
+            .scaleEffect(active ? 1.4 : 1)
+            .shadow(color: active ? .white.opacity(0.8) : .clear, radius: active ? 8 : 0)
+    }
+
+    private var buttonGrid: some View {
+        HStack(alignment: .top, spacing: 22) {
+            VStack(spacing: 22) {
+                circleButton("chevron.backward", control: .back)
+                circleButton("playpause.fill", control: .playPause)
+                circleButton("speaker.slash.fill")
+            }
+            VStack(spacing: 22) {
+                circleButton("tv")
+                volumeButton
+            }
+        }
+    }
+
+    private func circleButton(_ icon: String, control: RemoteControl? = nil) -> some View {
+        let active = control != nil && highlight == control
+        let relevant = control != nil
+        return Image(systemName: icon)
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundColor(active ? .white : .white.opacity(relevant ? 0.85 : 0.5))
+            .frame(width: 56, height: 56)
+            .background(Circle().fill(Color.white.opacity(active ? 0.3 : (relevant ? 0.14 : 0.07))))
+            .overlay(active ? Circle().stroke(Color.white, lineWidth: 2) : nil)
+            .scaleEffect(active ? 1.1 : 1)
+            .shadow(color: active ? .white.opacity(0.6) : .clear, radius: active ? 10 : 0)
+    }
+
+    private var volumeButton: some View {
+        VStack {
+            Image(systemName: "plus")
+            Spacer()
+            Image(systemName: "minus")
+        }
+        .font(.system(size: 16, weight: .semibold))
+        .foregroundColor(.white.opacity(0.5))
+        .padding(.vertical, 16)
+        .frame(width: 56, height: 134)
+        .background(Capsule().fill(Color.white.opacity(0.07)))
+    }
+}

--- a/app/BigImmich/Settings/SettingsView.swift
+++ b/app/BigImmich/Settings/SettingsView.swift
@@ -333,7 +333,7 @@ struct SettingsView: View {
             statusChip(configurationError, color: configurationErrorColour)
         } else if connectionTested {
             if connectionWorking {
-                statusChip("Connection to Immich works", color: .green)
+                statusChip("Connection to Immich works!", color: .green)
                 if outdatedServer {
                     footnote("This app is designed for Immich \(minimumImmichVersion.displayString) or newer. Updating Immich is recommended.", color: .yellow)
                 }

--- a/app/BigImmich/Settings/SettingsView.swift
+++ b/app/BigImmich/Settings/SettingsView.swift
@@ -3,6 +3,84 @@ import ImmichAPI
 import KeychainHelper
 import SwiftUI
 
+/// The left-sidebar categories. Moving focus onto one swaps the detail pane.
+enum SettingsCategory: String, CaseIterable, Identifiable {
+    case connection
+    case slideshow
+    case controls
+    case performance
+    case diagnostics
+    case about
+
+    var id: String {
+        rawValue
+    }
+
+    var title: String {
+        switch self {
+        case .connection: "Connection"
+        case .slideshow: "Slideshow"
+        case .controls: "Controls"
+        case .performance: "Performance"
+        case .diagnostics: "Diagnostics"
+        case .about: "About"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .connection: "link"
+        case .slideshow: "photo.on.rectangle"
+        case .controls: "av.remote"
+        case .performance: "speedometer"
+        case .diagnostics: "ladybug"
+        case .about: "info.circle"
+        }
+    }
+}
+
+/// One design system for the settings screen: fonts, sizes and the two colour sets — one for a
+/// row at rest (on the dark ground) and one for a focused/highlighted row (on the light card).
+enum SettingsDesign {
+    static let titleFont = Font.body
+    static let subtitleFont = Font.footnote
+    static let valueFont = Font.body
+    static let sectionFont = Font.caption
+
+    // At rest (dark ground)
+    static let title = Color.white
+    static let subtitle = Color.white.opacity(0.55)
+    static let value = Color.white.opacity(0.75)
+
+    // Focused / highlighted (light card)
+    static let titleFocused = Color.black
+    static let subtitleFocused = Color.black.opacity(0.6)
+    static let valueFocused = Color.black.opacity(0.7)
+
+    static let rowMinHeight: CGFloat = 78
+    static let cardFill = Color.white.opacity(0.05)
+    static let fieldFill = Color.white.opacity(0.10)
+    static let divider = Color.white.opacity(0.08)
+    static let cornerRadius: CGFloat = 14
+}
+
+/// Focus treatment for a right-side control (dropdown value, toggle switch, stepper button): a
+/// rounded fill + gentle lift when focused, so the control — not the whole row — highlights.
+private struct ControlFocusStyle: ButtonStyle {
+    @Environment(\.isFocused) private var isFocused
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isFocused ? Color.white.opacity(0.18) : Color.clear)
+            )
+            .scaleEffect(isFocused ? 1.06 : 1.0)
+            .animation(.easeInOut(duration: 0.12), value: isFocused)
+    }
+}
+
 struct SettingsView: View {
     // immich settings, saved to the Keychain
     @State private var immichURL: String = ""
@@ -35,8 +113,6 @@ struct SettingsView: View {
     @AppStorage("sentryEnabled") private var sentryEnabled: Bool = false
     @AppStorage("sentryDSN") private var sentryDSN: String = ""
 
-    @State private var fakedPickerOption: Int = 0 // helper for pickers with a single option
-
     @State private var errorWhileSaving: Bool = false
 
     @State private var configurationError: String?
@@ -47,607 +123,591 @@ struct SettingsView: View {
     @ObservedObject private var appLog = AppLog.shared
     @State private var outdatedServer = false
 
-    var immichClient: ImmichClientProtocol = ImmichClient.shared
+    @State private var selectedCategory: SettingsCategory = .connection
+    /// The sidebar is a single focus target (not one-per-category), so left from the detail always
+    /// returns here — to the selected category — instead of the geometrically nearest row.
+    @FocusState private var sidebarFocused: Bool
+    /// Which Controls-page row is focused, mirrored onto the on-screen remote so the highlighted
+    /// action lights up its button/gesture there too.
+    @FocusState private var focusedControl: RemoteControl?
 
-    private let leftSideWidth: CGFloat = 280
+    var immichClient: ImmichClientProtocol = ImmichClient.shared
+    var onExit: () -> Void = {}
+
     private let minimumImmichVersion = ServerVersion(major: 3, minor: 0, patch: 1)
 
+    private var showProgressBar: Binding<Bool> {
+        Binding(
+            get: { slideshowShowProgressBar == .always },
+            set: { slideshowShowProgressBar = $0 ? .always : .never }
+        )
+    }
+
     var body: some View {
-        GeometryReader { geo in
-            ScrollView(.vertical) {
-                HStack {
-                    Spacer()
-                    VStack(alignment: .leading, spacing: 30) {
-                        if errorWhileSaving {
-                            Text("Error saving settings!")
-                                .foregroundColor(.red)
-                                .bold()
-                        }
-
-                        HStack {
-                            Text("Auth method")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("Auth method", selection: $immichAuthMethod) {
-                                Text("api key (recommended)").tag(
-                                    ImmichAPIAuthMethod.apiKey
-                                )
-                                Text("password").tag(
-                                    ImmichAPIAuthMethod.emailAndPassword
-                                )
-                            }
-                            .pickerStyle(.inline)
-                            .frame(width: geo.size.width * 0.4)
-                            .onChange(of: immichAuthMethod, saveSettings)
-                        }
-
-                        HStack {
-                            Text("Immich URL")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            TextField("Enter Immich URL", text: $immichURL)
-                                .autocapitalization(.none)
-                                .disableAutocorrection(true)
-                                .keyboardType(.URL)
-                                .padding(8)
-                                .cornerRadius(6)
-                                .frame(width: geo.size.width * 0.4)
-                                .onChange(of: immichURL, saveSettings)
-                                .accessibilityIdentifier("immichURLField")
-                        }
-
-                        switch immichAuthMethod {
-                        case .apiKey:
-                            HStack {
-                                Text("API Key")
-                                    .frame(
-                                        width: leftSideWidth,
-                                        alignment: .leading
-                                    )
-                                    .bold()
-
-                                SecureField(
-                                    "Enter API Key",
-                                    text: $immichAuthAPIKey
-                                )
-                                .autocapitalization(.none)
-                                .disableAutocorrection(true)
-                                .padding(8)
-                                .cornerRadius(6)
-                                .frame(width: geo.size.width * 0.4)
-                                .onChange(of: immichAuthAPIKey, saveSettings)
-                                .accessibilityIdentifier("apiKeyField")
-                            }
-
-                            Text(
-                                "Required api key permissions: album.read, asset.view, asset.download"
-                            )
-                            .foregroundColor(.white)
-                            Text(
-                                "Tip: use the Apple TV remote app on your iPhone to copy the api key"
-                            )
-                            .foregroundColor(.white)
-
-                        case .emailAndPassword:
-                            HStack {
-                                Text("Email")
-                                    .frame(
-                                        width: leftSideWidth,
-                                        alignment: .leading
-                                    )
-                                    .bold()
-
-                                TextField("Enter email", text: $immichAuthEmail)
-                                    .autocapitalization(.none)
-                                    .disableAutocorrection(true)
-                                    .keyboardType(.emailAddress)
-                                    .padding(8)
-                                    .cornerRadius(6)
-                                    .frame(width: geo.size.width * 0.4)
-                                    .onChange(of: immichAuthEmail, saveSettings)
-                            }
-
-                            HStack {
-                                Text("Password")
-                                    .frame(
-                                        width: leftSideWidth,
-                                        alignment: .leading
-                                    )
-                                    .bold()
-
-                                SecureField(
-                                    "Enter password",
-                                    text: $immichAuthPassword
-                                )
-                                .autocapitalization(.none)
-                                .disableAutocorrection(true)
-                                .padding(8)
-                                .cornerRadius(6)
-                                .frame(width: geo.size.width * 0.4)
-                                .onChange(of: immichAuthPassword, saveSettings)
-                            }
-                        }
-
-                        if let configurationError {
-                            Text(configurationError).foregroundColor(
-                                configurationErrorColour
-                            )
-                        } else if connectionTested {
-                            if connectionWorking {
-                                Text("Connection to Immich works!")
-                                    .foregroundColor(.green)
-                                if outdatedServer {
-                                    Text(
-                                        "This app is designed for Immich \(minimumImmichVersion.displayString) or newer. Updating Immich is recommended."
-                                    )
-                                    .foregroundColor(.yellow)
-                                }
-                            } else {
-                                Text("Couldn't connect to Immich :(")
-                                    .foregroundColor(.red)
-                            }
-                        }
-
-                        Divider().frame(
-                            width: leftSideWidth + geo.size.width * 0.4
-                        )
-
-                        Text("Found an issue or a missing feature?").bold()
-                            .padding(.bottom, 10)
-
-                        Text("Report it on our GitHub to improve this app!")
-                        Text(
-                            "Visit: https://github.com/slakje-nl/big-immich"
-                        )
-
-                        Divider().frame(
-                            width: leftSideWidth + geo.size.width * 0.4
-                        )
-
-                        Text("Slideshow:")
-                            .frame(
-                                width: geo.size.width * 0.4,
-                                alignment: .leading
-                            )
-                            .bold()
-
-                        HStack {
-                            Text("Interval")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("Interval", selection: $slideshowInterval) {
-                                ForEach(5 ... 60, id: \.self) { i in
-                                    Text("\(i)s").tag(i)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                        }
-
-                        HStack {
-                            Text("Direction")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("Direction", selection: $slideshowDirection) {
-                                Text("oldest → newest").tag(
-                                    SlideshowDirection.oldestToNewest
-                                )
-                                Text("newest → oldest").tag(
-                                    SlideshowDirection.newestToOldest
-                                )
-                                Text("randomized").tag(
-                                    SlideshowDirection.randomized
-                                )
-                            }
-                            .pickerStyle(.menu)
-                        }
-
-                        HStack {
-                            Text("Once ended")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker(
-                                "Direction",
-                                selection: $slideshowOnceEndedAction
-                            ) {
-                                Text("stop and show a message").tag(
-                                    SlideshowOnceEndedAction.stopAndNotify
-                                )
-                                Text("start again").tag(
-                                    SlideshowOnceEndedAction.startAgain
-                                )
-                                Text(
-                                    "load another album (choose the next one below)"
-                                ).tag(
-                                    SlideshowOnceEndedAction.loadAnotherAlbum
-                                )
-                            }
-                            .pickerStyle(.menu)
-                        }
-
-                        if slideshowOnceEndedAction == .loadAnotherAlbum {
-                            HStack {
-                                Text("Next album")
-                                    .frame(
-                                        width: leftSideWidth,
-                                        alignment: .leading
-                                    )
-                                    .bold()
-
-                                Picker(
-                                    "Another album",
-                                    selection:
-                                    $slideshowOnceEndedAnotherAlbumSelection
-                                ) {
-                                    Text("older").tag(
-                                        SlideshowOnceEndedAnotherAlbumSelection
-                                            .older
-                                    )
-                                    Text("newer").tag(
-                                        SlideshowOnceEndedAnotherAlbumSelection
-                                            .newer
-                                    )
-                                    Text("random").tag(
-                                        SlideshowOnceEndedAnotherAlbumSelection
-                                            .random
-                                    )
-                                }
-                                .pickerStyle(.menu)
-                            }
-                        }
-
-                        HStack {
-                            Text("Progress bar")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker(
-                                "Progress bar",
-                                selection: $slideshowShowProgressBar
-                            ) {
-                                Text("show").tag(
-                                    SlideshowShowProgressBar.always
-                                )
-                                Text("don't show").tag(
-                                    SlideshowShowProgressBar.never
-                                )
-                            }
-                            .pickerStyle(.inline)
-                            .frame(width: geo.size.width * 0.3)
-                        }
-
-                        Divider().frame(
-                            width: leftSideWidth + geo.size.width * 0.4
-                        )
-
-                        Text("Slideshow controls:")
-                            .frame(
-                                width: geo.size.width * 0.4,
-                                alignment: .leading
-                            )
-                            .bold()
-
-                        HStack {
-                            Text("play")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("play", selection: $fakedPickerOption) {
-                                Text("play / pause").tag(0)
-                            }
-                            .pickerStyle(.menu)
-                        }
-
-                        HStack {
-                            Text("up (video)")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("up", selection: $fakedPickerOption) {
-                                Text("seek forward 15 seconds (if able)").tag(0)
-                            }
-                            .pickerStyle(.menu)
-                        }
-
-                        HStack {
-                            Text("down (video)")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("down", selection: $fakedPickerOption) {
-                                Text("seek backwards 15 seconds (if able)").tag(
-                                    0
-                                )
-                            }
-                            .pickerStyle(.menu)
-                        }
-
-                        HStack {
-                            Text("left")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("left", selection: $slideshowLeftAction) {
-                                Text("go to the next asset").tag(
-                                    SlideshowAction.goToNext
-                                )
-                                Text("go to the previous asset").tag(
-                                    SlideshowAction.goToPrevious
-                                )
-                            }
-                            .pickerStyle(.menu)
-                        }
-
-                        HStack {
-                            Text("right")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("left", selection: $slideshowRightAction) {
-                                Text("go to the next asset").tag(
-                                    SlideshowAction.goToNext
-                                )
-                                Text("go to the previous asset").tag(
-                                    SlideshowAction.goToPrevious
-                                )
-                            }
-                            .pickerStyle(.menu)
-                        }
-
-                        Divider().frame(
-                            width: leftSideWidth + geo.size.width * 0.4
-                        )
-
-                        Text("Performance:")
-                            .frame(
-                                width: geo.size.width * 0.4,
-                                alignment: .leading
-                            )
-                            .bold()
-
-                        HStack {
-                            Text("Slideshow quality")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker(
-                                "Slideshow quality",
-                                selection: $slideshowImageQuality
-                            ) {
-                                Text("thumbnail").tag(SlideshowImageQuality.thumbnail)
-                                Text("preview").tag(SlideshowImageQuality.preview)
-                                Text("full-size (recommended)").tag(SlideshowImageQuality.fullsize)
-                                Text("original").tag(SlideshowImageQuality.original)
-                            }
-                            .pickerStyle(.menu)
-                            .frame(
-                                width: geo.size.width * 0.4,
-                                alignment: .leading
-                            )
-                        }
-
-                        HStack {
-                            Text("Preload videos")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker(
-                                "Preload videos",
-                                selection: $slideshowPreloadVideos
-                            ) {
-                                Text("true").tag(true)
-                                Text("false").tag(false)
-                            }
-                            .pickerStyle(.inline)
-                            .frame(width: geo.size.width * 0.3)
-                        }
-
-                        Text("Warms the next video for a faster start; turn off if it causes playback issues.")
-                            .foregroundColor(.white)
-                            .frame(
-                                width: leftSideWidth + geo.size.width * 0.4,
-                                alignment: .leading
-                            )
-                            .multilineTextAlignment(.leading)
-
-                        HStack {
-                            Text("Cache thumbnails")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker(
-                                "Cache thumbnails",
-                                selection: $cacheThumbnails
-                            ) {
-                                Text("true").tag(true)
-                                Text("false").tag(false)
-                            }
-                            .pickerStyle(.inline)
-                            .frame(width: geo.size.width * 0.3)
-                        }
-
-                        HStack {
-                            Text("Cache slideshow")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker(
-                                "Cache slideshow",
-                                selection: $cacheFullSizeImages
-                            ) {
-                                Text("true").tag(true)
-                                Text("false").tag(false)
-                            }
-                            .pickerStyle(.inline)
-                            .frame(width: geo.size.width * 0.3)
-                        }
-
-                        Text("Caches full-size photos, uses more space.")
-                            .foregroundColor(.white)
-                            .frame(
-                                width: leftSideWidth + geo.size.width * 0.4,
-                                alignment: .leading
-                            )
-                            .multilineTextAlignment(.leading)
-
-                        HStack {
-                            Text("Cache size")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Text(imageCacheSize)
-
-                            Button("Clear cache") {
-                                clearImageCache()
-                            }
-                        }
-
-                        Divider().frame(
-                            width: leftSideWidth + geo.size.width * 0.4
-                        )
-
-                        Text("Error reporting: (may require restart)")
-                            .frame(
-                                width: geo.size.width * 0.4,
-                                alignment: .leading
-                            )
-                            .bold()
-
-                        HStack {
-                            Text("Enable Sentry")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Picker("Enable Sentry", selection: $sentryEnabled) {
-                                Text("true").tag(
-                                    true
-                                )
-                                Text("false").tag(
-                                    false
-                                )
-                            }
-                            .pickerStyle(.inline)
-                            .frame(width: geo.size.width * 0.3)
-                        }
-
-                        HStack {
-                            Text("Sentry DSN")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            TextField("Sentry DSN", text: $sentryDSN)
-                                .autocapitalization(.none)
-                                .padding(8)
-                                .cornerRadius(6)
-                                .frame(width: geo.size.width * 0.4)
-                        }
-
-                        Text(
-                            "When enabled and empty, error reporting is sent to the app's creator"
-                        )
-                        .foregroundColor(.white)
-
-                        Divider().frame(
-                            width: leftSideWidth + geo.size.width * 0.4
-                        )
-
-                        HStack {
-                            Text("Debug logs")
-                                .frame(
-                                    width: leftSideWidth,
-                                    alignment: .leading
-                                )
-                                .bold()
-
-                            Button("Clear logs") {
-                                appLog.clear()
-                            }
-                            .frame(
-                                width: geo.size.width * 0.4,
-                                alignment: .leading
-                            )
-                        }
-
-                        if appLog.entries.isEmpty {
-                            Text("No logs yet.").foregroundColor(.secondary)
-                        } else {
-                            VStack(alignment: .leading, spacing: 12) {
-                                ForEach(Array(appLog.entries.suffix(20).reversed())) { entry in
-                                    DebugLogRow(
-                                        entry: entry,
-                                        maxWidth: geo.size.width * 0.6
-                                    )
-                                }
-                            }
-                        }
-
-                        Spacer()
+        HStack(spacing: 0) {
+            sidebar
+            Rectangle()
+                .fill(SettingsDesign.divider)
+                .frame(width: 1)
+                .ignoresSafeArea()
+            detailPane
+        }
+        .onAppear {
+            loadSettings()
+            sidebarFocused = true
+        }
+        .onExitCommand {
+            // Two-stage back: from a detail control, return to the sidebar; from the sidebar,
+            // leave Settings.
+            if sidebarFocused {
+                onExit()
+            } else {
+                sidebarFocused = true
+            }
+        }
+    }
+
+    // MARK: - Sidebar
+
+    private var sidebar: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Settings")
+                .font(.title2).bold()
+                .padding(.horizontal, 18)
+                .padding(.bottom, 16)
+
+            ForEach(SettingsCategory.allCases) { category in
+                categoryRow(category)
+            }
+
+            Spacer()
+
+            goBackHint
+        }
+        .padding(.vertical, 40)
+        .padding(.horizontal, 24)
+        .frame(width: 340)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .contentShape(Rectangle())
+        .focusable()
+        .focused($sidebarFocused)
+        // The whole sidebar is one focus target: up/down change the category. Right/left are left to
+        // the focus engine — right enters the detail's `.focusSection()` (landing on its first
+        // control in one clean move), left returns here.
+        .onMoveCommand { direction in
+            switch direction {
+            case .up: moveCategory(by: -1)
+            case .down: moveCategory(by: 1)
+            default: break
+            }
+        }
+    }
+
+    private func categoryRow(_ category: SettingsCategory) -> some View {
+        let isSelected = selectedCategory == category
+        // The selected row highlights white while the sidebar is focused, grey when focus is in
+        // the detail pane — so you always see where you are.
+        let background: Color = isSelected
+            ? (sidebarFocused ? .white : Color.white.opacity(0.14))
+            : .clear
+        return HStack(spacing: 14) {
+            Image(systemName: category.icon)
+                .font(.body)
+                .frame(width: 26)
+            Text(category.title)
+                .font(.body)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 11)
+        .foregroundColor(isSelected && sidebarFocused ? .black : .white)
+        .background(RoundedRectangle(cornerRadius: 12).fill(background))
+        .animation(.easeInOut(duration: 0.12), value: sidebarFocused)
+        .animation(.easeInOut(duration: 0.12), value: isSelected)
+    }
+
+    private func moveCategory(by offset: Int) {
+        let all = SettingsCategory.allCases
+        guard let index = all.firstIndex(of: selectedCategory) else { return }
+        let next = index + offset
+        guard all.indices.contains(next) else { return }
+        selectedCategory = all[next]
+    }
+
+    private var goBackHint: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "chevron.backward")
+            Text("Back to leave")
+        }
+        .font(.footnote)
+        .foregroundColor(.secondary)
+        .padding(.horizontal, 16)
+        .padding(.top, 8)
+    }
+
+    // MARK: - Detail
+
+    private var detailPane: some View {
+        ScrollView(.vertical) {
+            VStack(alignment: .leading, spacing: 20) {
+                switch selectedCategory {
+                case .connection: connectionDetail
+                case .slideshow: slideshowDetail
+                case .controls: controlsDetail
+                case .performance: performanceDetail
+                case .diagnostics: diagnosticsDetail
+                case .about: aboutDetail
+                }
+            }
+            .padding(.horizontal, 56)
+            .padding(.vertical, 48)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        // Treat the detail as one focus region so a right-press from the sidebar lands on its first
+        // control directly, and a left-press returns to the sidebar.
+        .focusSection()
+    }
+
+    // MARK: - Connection
+
+    @ViewBuilder
+    private var connectionDetail: some View {
+        if errorWhileSaving {
+            Text("Error saving settings!").foregroundColor(.red).bold()
+        }
+
+        card {
+            pickerRow(
+                "Auth method",
+                value: $immichAuthMethod,
+                options: [("API key (recommended)", .apiKey), ("email & password", .emailAndPassword)],
+                first: true,
+                onChange: saveSettings
+            )
+            rowDivider
+            EditableFieldRow(
+                title: "Immich URL",
+                placeholder: "https://immich.example.com",
+                accessibilityID: "immichURLField",
+                text: $immichURL,
+                onChange: saveSettings
+            )
+            rowDivider
+            switch immichAuthMethod {
+            case .apiKey:
+                EditableFieldRow(
+                    title: "API key",
+                    subtitle: "Needs album.read, asset.view, asset.download.",
+                    placeholder: "Enter API key",
+                    secure: true,
+                    accessibilityID: "apiKeyField",
+                    text: $immichAuthAPIKey,
+                    onChange: saveSettings
+                )
+            case .emailAndPassword:
+                EditableFieldRow(
+                    title: "Email",
+                    placeholder: "Enter email",
+                    text: $immichAuthEmail,
+                    onChange: saveSettings
+                )
+                rowDivider
+                EditableFieldRow(
+                    title: "Password",
+                    placeholder: "Enter password",
+                    secure: true,
+                    text: $immichAuthPassword,
+                    onChange: saveSettings
+                )
+            }
+        }
+
+        footnote("Tip: paste your \(immichAuthMethod == .apiKey ? "API key" : "password") using the Apple TV remote app on your iPhone.")
+
+        connectionStatus
+    }
+
+    @ViewBuilder
+    private var connectionStatus: some View {
+        if let configurationError {
+            statusChip(configurationError, color: configurationErrorColour)
+        } else if connectionTested {
+            if connectionWorking {
+                statusChip("Connection to Immich works", color: .green)
+                if outdatedServer {
+                    footnote("This app is designed for Immich \(minimumImmichVersion.displayString) or newer. Updating Immich is recommended.", color: .yellow)
+                }
+            } else {
+                statusChip("Couldn't connect to Immich", color: .red)
+            }
+        }
+    }
+
+    // MARK: - Slideshow
+
+    private var slideshowDetail: some View {
+        card {
+            pickerRow("Slide interval", value: $slideshowInterval, options: slideIntervalOptions, first: true)
+            rowDivider
+            pickerRow(
+                "Direction",
+                value: $slideshowDirection,
+                options: [
+                    ("oldest → newest", .oldestToNewest),
+                    ("newest → oldest", .newestToOldest),
+                    ("randomized", .randomized)
+                ]
+            )
+            rowDivider
+            pickerRow(
+                "When an album ends",
+                value: $slideshowOnceEndedAction,
+                options: [
+                    ("stop and show a message", .stopAndNotify),
+                    ("start again", .startAgain),
+                    ("load another album", .loadAnotherAlbum)
+                ]
+            )
+            if slideshowOnceEndedAction == .loadAnotherAlbum {
+                rowDivider
+                pickerRow(
+                    "Next album",
+                    value: $slideshowOnceEndedAnotherAlbumSelection,
+                    options: [("older", .older), ("newer", .newer), ("random", .random)]
+                )
+            }
+            rowDivider
+            toggleRow("Show progress bar", isOn: showProgressBar)
+        }
+    }
+
+    // MARK: - Controls
+
+    private var controlsDetail: some View {
+        HStack(alignment: .top, spacing: 56) {
+            RemoteDiagramView(highlight: focusedControl)
+                .frame(height: 820)
+
+            VStack(alignment: .leading, spacing: 16) {
+                sectionHeader("What each control does")
+                card {
+                    controlRow(.up, title: "Up") { staticControlValue("open the options menu") }
+                    rowDivider
+                    controlRow(.down, title: "Down") { staticControlValue("show the progress bar (movies only)") }
+                    rowDivider
+                    editableControlRow(.left, title: "Left", value: $slideshowLeftAction)
+                    rowDivider
+                    editableControlRow(.right, title: "Right", value: $slideshowRightAction)
+                    rowDivider
+                    controlRow(.back, title: "Back") { staticControlValue("exit · close the menu") }
+                    rowDivider
+                    controlRow(.playPause, title: "Play / pause") { staticControlValue("pause or resume") }
+                }
+                footnote("Left and right scrub the video while it is paused.")
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxHeight: .infinity, alignment: .top)
+    }
+
+    private var directionOptions: [(String, SlideshowAction)] {
+        [("next asset", .goToNext), ("previous asset", .goToPrevious)]
+    }
+
+    /// 1–10s in 1s steps, then 12/15/20s, then every 5s up to 60s.
+    private var slideIntervalOptions: [(String, Int)] {
+        let values = Array(1 ... 10) + [12, 15, 20] + stride(from: 25, through: 60, by: 5)
+        return values.map { ("\($0) second\($0 == 1 ? "" : "s")", $0) }
+    }
+
+    /// A Controls-page row: an icon + gesture/button name, and its effect on the right. The whole
+    /// row is focusable so highlighting it lights up the matching control on the remote.
+    private func controlRow(_ control: RemoteControl, title: String, @ViewBuilder value: () -> some View) -> some View {
+        controlRowBody(control, title: title, value: value)
+            .focusable()
+            .focused($focusedControl, equals: control)
+    }
+
+    /// A Controls-page row whose effect is a configurable Left/Right action. The dropdown carries
+    /// the focus (and thus the remote highlight).
+    private func editableControlRow(_ control: RemoteControl, title: String, value: Binding<SlideshowAction>) -> some View {
+        controlRowBody(control, title: title) {
+            directionMenu(value)
+                .focused($focusedControl, equals: control)
+        }
+    }
+
+    private func controlRowBody(_ control: RemoteControl, title: String, @ViewBuilder value: () -> some View) -> some View {
+        HStack(spacing: 18) {
+            Image(systemName: control.icon)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.white.opacity(0.8))
+                .frame(width: 34, height: 34)
+                .background(Circle().fill(Color.white.opacity(0.08)))
+            Text(title).font(SettingsDesign.titleFont).foregroundColor(SettingsDesign.title)
+            Spacer(minLength: 24)
+            value()
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 14)
+        .frame(minHeight: SettingsDesign.rowMinHeight)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(focusedControl == control ? Color.white.opacity(0.10) : .clear)
+        )
+        .animation(.easeInOut(duration: 0.12), value: focusedControl)
+    }
+
+    private func staticControlValue(_ text: String) -> some View {
+        Text(text).font(SettingsDesign.valueFont).foregroundColor(SettingsDesign.value)
+    }
+
+    private func directionMenu(_ value: Binding<SlideshowAction>) -> some View {
+        Menu {
+            ForEach(directionOptions, id: \.1) { option in
+                Button {
+                    value.wrappedValue = option.1
+                } label: {
+                    if value.wrappedValue == option.1 {
+                        Label(option.0, systemImage: "checkmark")
+                    } else {
+                        Text(option.0)
                     }
-                    .padding(40)
-                    .onAppear(perform: loadSettings)
-                    Spacer() // push everything to center horizontally
+                }
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Text(directionOptions.first { $0.1 == value.wrappedValue }?.0 ?? "")
+                Image(systemName: "chevron.down").font(.caption)
+            }
+        }
+    }
+
+    // MARK: - Performance
+
+    private var performanceDetail: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            card {
+                pickerRow(
+                    "Photo quality",
+                    value: $slideshowImageQuality,
+                    options: [
+                        ("thumbnail", .thumbnail),
+                        ("preview", .preview),
+                        ("full-size (recommended)", .fullsize),
+                        ("original", .original)
+                    ],
+                    first: true
+                )
+                rowDivider
+                toggleRow(
+                    "Preload videos",
+                    subtitle: "Warms the next video for a faster start; turn off if it causes playback issues.",
+                    isOn: $slideshowPreloadVideos
+                )
+            }
+
+            sectionHeader("On-disk cache")
+            card {
+                toggleRow("Cache thumbnails", isOn: $cacheThumbnails)
+                rowDivider
+                toggleRow(
+                    "Cache full-size photos",
+                    subtitle: "Speeds up repeat views but uses more storage.",
+                    isOn: $cacheFullSizeImages
+                )
+                rowDivider
+                rowShell("Cache size") {
+                    HStack(spacing: 16) {
+                        Text(imageCacheSize).font(SettingsDesign.valueFont).foregroundColor(SettingsDesign.value)
+                        Button("Clear", action: clearImageCache)
+                            .buttonStyle(ControlFocusStyle())
+                    }
                 }
             }
         }
     }
+
+    // MARK: - Diagnostics
+
+    private var diagnosticsDetail: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            sectionHeader("Error reporting (may require restart)")
+            card {
+                toggleRow("Enable error reporting to Sentry", isOn: $sentryEnabled, first: true)
+                if sentryEnabled {
+                    rowDivider
+                    EditableFieldRow(title: "Sentry DSN", placeholder: "Enter a DSN", text: $sentryDSN)
+                }
+            }
+
+            sectionHeader("Debug logs")
+            HStack {
+                Text("Recent errors captured on this device").font(.body)
+                Spacer()
+                Button("Clear logs") { appLog.clear() }
+            }
+
+            if appLog.entries.isEmpty {
+                Text("No logs yet.").foregroundColor(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(Array(appLog.entries.suffix(20).reversed())) { entry in
+                        DebugLogRow(entry: entry, maxWidth: 900)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - About
+
+    private var aboutDetail: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            sectionHeader("App")
+            card {
+                rowShell("App version") {
+                    Text(appVersion).font(SettingsDesign.valueFont).foregroundColor(SettingsDesign.value)
+                }
+                rowDivider
+                rowShell("Designed for Immich") {
+                    Text("\(minimumImmichVersion.displayString) or newer")
+                        .font(SettingsDesign.valueFont).foregroundColor(SettingsDesign.value)
+                }
+            }
+
+            sectionHeader("Feedback")
+            card {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(spacing: 24) {
+                        Text("Project website").font(SettingsDesign.titleFont).foregroundColor(SettingsDesign.title)
+                        Spacer(minLength: 24)
+                        Text("github.com/slakje-nl/big-immich")
+                            .font(SettingsDesign.valueFont).foregroundColor(SettingsDesign.value)
+                    }
+                    Text("Found a bug or a missing feature?\nOpen an issue there to improve the app.")
+                        .font(SettingsDesign.subtitleFont)
+                        .foregroundColor(SettingsDesign.subtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.horizontal, 22)
+                .padding(.vertical, 16)
+            }
+
+            footnote("This is a community app that displays Immich photo & video slideshows on Apple TV. It is not affiliated with Immich.")
+        }
+    }
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+    }
+
+    // MARK: - Reusable rows
+
+    private func card(@ViewBuilder _ content: () -> some View) -> some View {
+        VStack(spacing: 0) { content() }
+            .background(SettingsDesign.cardFill)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// One consistent row shape: a static title (+ optional description) on the left, and a
+    /// focusable control on the right — so a dropdown, toggle, stepper and text field all line up
+    /// and highlight the *control*, not the whole row (matching the text-field rows).
+    private func rowShell(_ title: String, subtitle: String? = nil, @ViewBuilder control: () -> some View) -> some View {
+        HStack(spacing: 24) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).font(SettingsDesign.titleFont).foregroundColor(SettingsDesign.title)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(SettingsDesign.subtitleFont)
+                        .foregroundColor(SettingsDesign.subtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 24)
+            control()
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 14)
+        .frame(minHeight: SettingsDesign.rowMinHeight)
+    }
+
+    /// A dropdown (native Menu) — the value on the right opens a list of options.
+    private func pickerRow<Value: Hashable>(
+        _ title: String,
+        subtitle: String? = nil,
+        value: Binding<Value>,
+        options: [(String, Value)],
+        first _: Bool = false,
+        onChange: (() -> Void)? = nil
+    ) -> some View {
+        rowShell(title, subtitle: subtitle) {
+            Menu {
+                ForEach(options, id: \.1) { option in
+                    Button {
+                        value.wrappedValue = option.1
+                        onChange?()
+                    } label: {
+                        if value.wrappedValue == option.1 {
+                            Label(option.0, systemImage: "checkmark")
+                        } else {
+                            Text(option.0)
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Text(options.first { $0.1 == value.wrappedValue }?.0 ?? "")
+                    Image(systemName: "chevron.down").font(.caption)
+                }
+            }
+        }
+    }
+
+    /// A boolean toggle — a focusable switch on the right, flipped with the select button.
+    private func toggleRow(_ title: String, subtitle: String? = nil, isOn: Binding<Bool>, first _: Bool = false) -> some View {
+        rowShell(title, subtitle: subtitle) {
+            Button { isOn.wrappedValue.toggle() } label: {
+                switchGraphic(isOn.wrappedValue)
+            }
+            .buttonStyle(ControlFocusStyle())
+        }
+    }
+
+    private func switchGraphic(_ isOn: Bool) -> some View {
+        Capsule()
+            .fill(isOn ? Color.green : Color.white.opacity(0.25))
+            .frame(width: 52, height: 30)
+            .overlay(Circle().fill(.white).padding(3), alignment: isOn ? .trailing : .leading)
+    }
+
+    private var rowDivider: some View {
+        Rectangle().fill(SettingsDesign.divider).frame(height: 1)
+    }
+
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(SettingsDesign.sectionFont).fontWeight(.semibold)
+            .tracking(1.1)
+            .foregroundColor(.secondary)
+            .padding(.leading, 6)
+            .padding(.top, 6)
+    }
+
+    private func footnote(_ text: String, color: Color = .secondary) -> some View {
+        Text(text)
+            .font(.callout)
+            .foregroundColor(color)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func statusChip(_ text: String, color: Color) -> some View {
+        Text(text).font(.body).foregroundColor(color)
+    }
+
+    // MARK: - Persistence & validation
 
     private func saveSettings() {
         let savedUrl = KeychainHelper.saveImmichURL(url: immichURL)
@@ -711,7 +771,7 @@ struct SettingsView: View {
 
         if !isValidHTTPURL(immichURL) {
             configurationError =
-                "wrong Immich URL (maybe missing http:// or https://)"
+                "Wrong Immich URL (maybe missing http:// or https://)"
         }
 
         Task {
@@ -737,13 +797,60 @@ struct SettingsView: View {
             connectionTested = false
 
             configurationErrorColour = .yellow
-            configurationError = "caution: missing configuration"
+            configurationError = "Caution: missing configuration"
         } catch {
             connectionTested = true
             connectionWorking = false
 
             configurationErrorColour = .red
-            configurationError = "error: \(error.localizedDescription)"
+            configurationError = "Error: \(error.localizedDescription)"
+        }
+    }
+}
+
+/// A settings row whose value is entered with the on-screen keyboard. It's a real text field, so a
+/// single click opens the keyboard directly (no intermediate "edit" step). Styled as a light pill;
+/// the row is a touch taller than the others to give the field room to breathe.
+private struct EditableFieldRow: View {
+    let title: String
+    var subtitle: String?
+    var placeholder: String = ""
+    var secure: Bool = false
+    var accessibilityID: String?
+    @Binding var text: String
+    var onChange: () -> Void = {}
+
+    private let fieldWidth: CGFloat = 720
+
+    var body: some View {
+        HStack(spacing: 24) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).font(SettingsDesign.titleFont).foregroundColor(SettingsDesign.title)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(SettingsDesign.subtitleFont)
+                        .foregroundColor(SettingsDesign.subtitle)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer(minLength: 24)
+            field
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .accessibilityIdentifier(accessibilityID ?? "")
+                .frame(width: fieldWidth)
+                .onChange(of: text) { _, _ in onChange() }
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 16)
+        .frame(minHeight: SettingsDesign.rowMinHeight + 12)
+    }
+
+    @ViewBuilder private var field: some View {
+        if secure {
+            SecureField(placeholder, text: $text)
+        } else {
+            TextField(placeholder, text: $text)
         }
     }
 }

--- a/app/BigImmich/Settings/Typing.swift
+++ b/app/BigImmich/Settings/Typing.swift
@@ -91,6 +91,7 @@ protocol SlideshowSettingsProtocol {
     var slideshowShowProgressBar: SlideshowShowProgressBar { get set }
     var slideshowImageQuality: SlideshowImageQuality { get set }
     var slideshowPreloadVideos: Bool { get set }
+    var slideshowShowVideoStats: Bool { get set }
 }
 
 final class SlideshowSettings: ObservableObject, SlideshowSettingsProtocol {
@@ -107,4 +108,5 @@ final class SlideshowSettings: ObservableObject, SlideshowSettingsProtocol {
     @AppStorage("slideshowShowProgressBar") var slideshowShowProgressBar: SlideshowShowProgressBar = .always
     @AppStorage("slideshowImageQuality") var slideshowImageQuality: SlideshowImageQuality = .fullsize
     @AppStorage("slideshowPreloadVideos") var slideshowPreloadVideos: Bool = true
+    @AppStorage("slideshowShowVideoStats") var slideshowShowVideoStats: Bool = false
 }

--- a/app/BigImmich/Slideshow/SlideshowView.swift
+++ b/app/BigImmich/Slideshow/SlideshowView.swift
@@ -34,6 +34,49 @@ struct SlideshowView: View {
     }
 
     var body: some View {
+        // Route the select/click through a Button primary action, not `.onTapGesture`: on tvOS a
+        // touchpad click reaches a focused Button's action reliably (even with slight movement),
+        // whereas a tap gesture on a bare focusable view is missed most of the time.
+        Button {
+            viewModel.handleSelect()
+        } label: {
+            content
+        }
+        .buttonStyle(SlideshowSurfaceButtonStyle())
+        .onAppear {
+            Task {
+                await viewModel.start()
+            }
+        }
+        .onDisappear {
+            viewModel.stop()
+        }
+        .onExitCommand {
+            // The options overlay swallows the back button to close itself, not the slideshow.
+            if viewModel.showOptionsMenu {
+                viewModel.closeOptionsMenu()
+                return
+            }
+
+            viewModel.clearImageCache()
+
+            if let asset = viewModel.slideshowAsset {
+                onExit(asset.album.id, asset.album.albumName, asset.asset.id)
+            } else {
+                onExit(initialAlbumID, initialAlbumName, initialAssetID)
+            }
+        }
+        .onMoveCommand { direction in
+            Task {
+                await viewModel.handleMoveCommand(direction)
+            }
+        }
+        .onPlayPauseCommand {
+            viewModel.togglePause()
+        }
+    }
+
+    private var content: some View {
         ZStack {
             Color.black.ignoresSafeArea()
 
@@ -90,41 +133,6 @@ struct SlideshowView: View {
             if !viewModel.errors.isEmpty || !viewModel.informations.isEmpty {
                 messagesOverlay
             }
-        }
-        .focusable(true)
-        .onAppear {
-            Task {
-                await viewModel.start()
-            }
-        }
-        .onDisappear {
-            viewModel.stop()
-        }
-        .onExitCommand {
-            // The options overlay swallows the back button to close itself, not the slideshow.
-            if viewModel.showOptionsMenu {
-                viewModel.closeOptionsMenu()
-                return
-            }
-
-            viewModel.clearImageCache()
-
-            if let asset = viewModel.slideshowAsset {
-                onExit(asset.album.id, asset.album.albumName, asset.asset.id)
-            } else {
-                onExit(initialAlbumID, initialAlbumName, initialAssetID)
-            }
-        }
-        .onMoveCommand { direction in
-            Task {
-                await viewModel.handleMoveCommand(direction)
-            }
-        }
-        .onPlayPauseCommand {
-            viewModel.togglePause()
-        }
-        .onTapGesture {
-            viewModel.handleSelect()
         }
     }
 
@@ -529,5 +537,13 @@ struct SlideshowView: View {
         }
         .transition(.opacity.combined(with: .move(edge: .trailing)))
         .animation(.easeInOut, value: viewModel.errors)
+    }
+}
+
+/// The slideshow surface is a Button (for reliable select handling) but must look untouched — no
+/// focus lift, tint or scale. This style renders the label exactly as-is.
+private struct SlideshowSurfaceButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
     }
 }

--- a/app/BigImmich/Slideshow/SlideshowView.swift
+++ b/app/BigImmich/Slideshow/SlideshowView.swift
@@ -446,10 +446,12 @@ struct SlideshowView: View {
     private func optionRowValue(_ row: SlideshowViewModel.OptionRow) -> some View {
         switch row {
         case .interval:
+            // Hide the chevron once the value can't move that way, but keep it occupying its space
+            // (opacity, not removal) so the number stays put.
             HStack(spacing: 12) {
-                Text("‹").foregroundColor(.white.opacity(0.4))
+                Text("‹").foregroundColor(.white.opacity(viewModel.displayInterval <= 1 ? 0 : 0.4))
                 Text("\(viewModel.displayInterval)s").foregroundColor(.white.opacity(0.85))
-                Text("›").foregroundColor(.white.opacity(0.4))
+                Text("›").foregroundColor(.white.opacity(viewModel.displayInterval >= 60 ? 0 : 0.4))
             }
         case .toggleStats:
             Capsule()

--- a/app/BigImmich/Slideshow/SlideshowView.swift
+++ b/app/BigImmich/Slideshow/SlideshowView.swift
@@ -10,6 +10,9 @@ struct SlideshowView: View {
 
     @State private var viewModel: SlideshowViewModel
     @State private var assetDetailsTimer: Timer?
+    /// A mid-stream rebuffer only surfaces the "Buffering…" overlay once it has lasted past a short
+    /// grace window, so brief stalls don't flash it on and off.
+    @State private var showBufferingOverlay = false
 
     init(
         initialAlbumID: AlbumID,
@@ -43,10 +46,7 @@ struct SlideshowView: View {
                     PlayerLayerView(player: player)
                         .ignoresSafeArea()
                         .overlay {
-                            if viewModel.videoState == .loading {
-                                ProgressView()
-                                    .scaleEffect(1.5)
-                            }
+                            videoBufferingOverlay
                         }
                 } else if let image = viewModel.currentImage {
                     image
@@ -57,12 +57,34 @@ struct SlideshowView: View {
                 }
             }
 
-            if !viewModel.slideshowIsRunning {
+            if !viewModel.slideshowIsRunning, !viewModel.showOptionsMenu {
                 pausedOverlay
+            }
+
+            // The options overlay pauses playback; a small pause badge shows it's paused,
+            // without the full paused overlay's asset details.
+            if viewModel.showOptionsMenu, viewModel.currentImage != nil {
+                imagePausedBadge
+            }
+
+            if viewModel.showVideoScrubber {
+                videoScrubber
             }
 
             if viewModel.settings.slideshowShowProgressBar == .always {
                 progressBar
+            }
+
+            if viewModel.showVideoStats, viewModel.currentPlayer != nil {
+                videoStatsOverlay
+            }
+
+            if viewModel.showVideoStats, viewModel.currentImage != nil {
+                photoStatsOverlay
+            }
+
+            if viewModel.showOptionsMenu {
+                optionsMenuOverlay
             }
 
             if !viewModel.errors.isEmpty || !viewModel.informations.isEmpty {
@@ -79,6 +101,12 @@ struct SlideshowView: View {
             viewModel.stop()
         }
         .onExitCommand {
+            // The options overlay swallows the back button to close itself, not the slideshow.
+            if viewModel.showOptionsMenu {
+                viewModel.closeOptionsMenu()
+                return
+            }
+
             viewModel.clearImageCache()
 
             if let asset = viewModel.slideshowAsset {
@@ -95,35 +123,45 @@ struct SlideshowView: View {
         .onPlayPauseCommand {
             viewModel.togglePause()
         }
+        .onTapGesture {
+            viewModel.handleSelect()
+        }
     }
 
     private var pausedOverlay: some View {
-        VStack {
+        // In video mode the scrubber (video progress bar) sits at the bottom, so drop the pause
+        // icon and lift the asset number to sit just above the scrubber.
+        let isVideo = viewModel.currentPlayer != nil
+        return VStack {
             Spacer()
             HStack {
-                Image(systemName: "pause.fill")
-                    .font(.largeTitle)
-                    .foregroundColor(.white.opacity(0.9))
-                    .padding(20)
-                    .background(
-                        Circle()
-                            .fill(Color.black.opacity(0.4))
-                            .shadow(
-                                color: Color.black.opacity(0.6),
-                                radius: 6,
-                                x: 0,
-                                y: 0
-                            )
-                    )
-                    .padding(.leading, 40)
+                if !isVideo {
+                    Image(systemName: "pause.fill")
+                        .font(.largeTitle)
+                        .foregroundColor(.white.opacity(0.9))
+                        .padding(20)
+                        .background(
+                            Circle()
+                                .fill(Color.black.opacity(0.4))
+                                .shadow(
+                                    color: Color.black.opacity(0.6),
+                                    radius: 6,
+                                    x: 0,
+                                    y: 0
+                                )
+                        )
+                        .padding(.leading, 40)
+                }
 
                 Spacer()
 
                 if viewModel.showAssetDetails {
+                    // Line the box's right edge up with the scrubber (same 60pt inset).
                     assetDetails
+                        .padding(.trailing, isVideo ? 60 : 0)
                 }
             }
-            .padding(.bottom, 40)
+            .padding(.bottom, isVideo ? 170 : 40)
         }
         .transition(.opacity)
     }
@@ -186,6 +224,275 @@ struct SlideshowView: View {
                 )
         }
         .ignoresSafeArea()
+    }
+
+    /// Spinner shown while the video is loading its first data or rebuffering mid-stream.
+    /// "Buffering…" tells the viewer we're waiting on the network, not stuck — but only after a
+    /// mid-stream rebuffer has persisted past a short grace window, so brief stalls don't flash it.
+    private var videoBufferingOverlay: some View {
+        ZStack {
+            if viewModel.videoState == .loading {
+                ProgressView().scaleEffect(1.5)
+            } else if viewModel.videoState == .buffering, showBufferingOverlay {
+                VStack(spacing: 12) {
+                    ProgressView()
+                        .scaleEffect(1.5)
+                    Text("Buffering…")
+                        .font(.headline)
+                        .foregroundColor(.white.opacity(0.85))
+                        .shadow(color: .black.opacity(0.8), radius: 2)
+                }
+            }
+        }
+        .task(id: viewModel.videoState) {
+            guard viewModel.videoState == .buffering else {
+                showBufferingOverlay = false
+                return
+            }
+            showBufferingOverlay = false
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled else { return }
+            showBufferingOverlay = true
+        }
+    }
+
+    /// The video progress bar. It shows a pause indicator while paused, and always shows what
+    /// left/right will do: scrub ±N seconds while paused mid-video, or change to the prev/next
+    /// asset at the very start/end — or, while playing (a down-button peek), asset changes too,
+    /// since left/right move between assets then.
+    private var videoScrubber: some View {
+        // The bar only shows when left/right scrub (paused, or a peek) — so hints are scrub unless
+        // at the very start/end, where they flip to the configured prev/next-asset action.
+        let paused = !viewModel.slideshowIsRunning
+        let step = viewModel.videoScrubStepSeconds
+        let leftHint = viewModel.videoAtStart ? "‹ \(assetActionLabel(viewModel.settings.slideshowLeftAction))" : "‹ \(step)s"
+        let rightHint = viewModel.videoAtEnd ? "\(assetActionLabel(viewModel.settings.slideshowRightAction)) ›" : "\(step)s ›"
+        return VStack {
+            Spacer()
+            VStack(spacing: 8) {
+                HStack {
+                    Text(leftHint)
+                    Spacer()
+                    Text(rightHint)
+                }
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.6))
+
+                GeometryReader { geometry in
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(Color.white.opacity(0.25))
+                            .frame(height: 6)
+                        Capsule()
+                            .fill(Color.white)
+                            .frame(
+                                width: geometry.size.width * viewModel.assetProgress,
+                                height: 6
+                            )
+                    }
+                }
+                .frame(height: 6)
+
+                HStack(spacing: 8) {
+                    if paused {
+                        Image(systemName: "pause.fill")
+                    }
+                    Text(SlideshowView.timeLabel(viewModel.videoDisplaySeconds))
+                    Spacer()
+                    Text(SlideshowView.timeLabel(viewModel.videoDurationSeconds))
+                }
+                .font(.caption)
+                .foregroundColor(.white.opacity(0.9))
+            }
+            .padding(.horizontal, 60)
+            .padding(.bottom, 80)
+        }
+        .transition(.opacity)
+    }
+
+    /// The optional "nerd stats" overlay: live bitrate, resolution, buffer and stall counters.
+    private var videoStatsOverlay: some View {
+        let stats = viewModel.videoStats
+        return VStack(alignment: .leading, spacing: 4) {
+            if stats.resolution != .zero {
+                statLine("Resolution", "\(Int(stats.resolution.width))×\(Int(stats.resolution.height))")
+            }
+            if !stats.codec.isEmpty {
+                statLine("Codec", stats.codec)
+            }
+            if stats.frameRate > 0 {
+                statLine("Frame rate", String(format: "%.0f fps", stats.frameRate))
+            }
+            if !stats.colorSpace.isEmpty {
+                statLine("Colour", stats.colorSpace)
+            }
+            statLine("Bitrate", SlideshowView.bitrateLabel(stats.indicatedBitrate))
+            statLine("Observed", SlideshowView.bitrateLabel(stats.observedBitrate))
+            statLine("Buffer", String(format: "%.1fs", stats.bufferedAhead))
+            statLine("Stalls", "\(stats.stalls)")
+        }
+        .font(.system(.caption, design: .monospaced))
+        .foregroundColor(.green)
+        .padding(12)
+        .background(Color.black.opacity(0.55))
+        .cornerRadius(8)
+        .padding(.top, 40)
+        .padding(.leading, 40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    /// A small pause badge shown while the options overlay is open over a photo.
+    private var imagePausedBadge: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Image(systemName: "pause.fill")
+                    .font(.largeTitle)
+                    .foregroundColor(.white.opacity(0.9))
+                    .padding(20)
+                    .background(Circle().fill(Color.black.opacity(0.4)))
+                    .padding(.leading, 40)
+                Spacer()
+            }
+            .padding(.bottom, 40)
+        }
+    }
+
+    /// The optional "nerd stats" overlay for photos: file name, dimensions and size, from the
+    /// full asset's EXIF (fetched into `detailedAsset`, since the search EXIF is partial).
+    private var photoStatsOverlay: some View {
+        let asset = viewModel.detailedAsset ?? viewModel.slideshowAsset?.asset
+        let exif = asset?.exifInfo
+        return VStack(alignment: .leading, spacing: 4) {
+            if let name = asset?.originalFileName, !name.isEmpty {
+                statLine("File", name)
+            }
+            if let width = exif?.exifImageWidth, let height = exif?.exifImageHeight {
+                statLine("Dimensions", "\(width) × \(height)")
+            }
+            if let bytes = exif?.fileSizeInByte {
+                statLine("Size", ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file))
+            }
+            if asset == nil || (asset?.originalFileName == nil && exif?.exifImageWidth == nil) {
+                statLine("Metadata", "loading…")
+            }
+        }
+        .font(.system(.caption, design: .monospaced))
+        .foregroundColor(.green)
+        .padding(12)
+        .background(Color.black.opacity(0.55))
+        .cornerRadius(8)
+        .padding(.top, 40)
+        .padding(.leading, 40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    /// The in-slideshow options overlay (up button). A card anchored to the right so the
+    /// slideshow stays visible behind it. Photos show the interval + nerd stats; videos show
+    /// nerd stats. Up/down navigate rows, left/right adjust the interval, select flips a toggle.
+    private var optionsMenuOverlay: some View {
+        HStack {
+            Spacer()
+            VStack(alignment: .leading, spacing: 4) {
+                Text(viewModel.currentPlayer != nil ? "Video options" : "Slideshow")
+                    .font(.title3).bold()
+                    .foregroundColor(.white)
+                    .padding(.bottom, 12)
+
+                ForEach(Array(viewModel.optionsMenuItems.enumerated()), id: \.element.id) { index, row in
+                    HStack(spacing: 16) {
+                        optionRowLabel(row).foregroundColor(.white)
+                        Spacer(minLength: 24)
+                        optionRowValue(row)
+                    }
+                    .lineLimit(1)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+                    .background(
+                        index == viewModel.optionsMenuIndex
+                            ? Color.white.opacity(0.22) : Color.clear
+                    )
+                    .cornerRadius(8)
+                }
+
+                Text("◀ Back")
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.5))
+                    .padding(.top, 14)
+                    .padding(.horizontal, 20)
+            }
+            .padding(32)
+            .frame(width: 480)
+            .background(.black.opacity(0.82))
+            .cornerRadius(20)
+            .shadow(color: .black.opacity(0.5), radius: 20)
+            .padding(.trailing, 60)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .transition(.move(edge: .trailing).combined(with: .opacity))
+    }
+
+    private func optionRowLabel(_ row: SlideshowViewModel.OptionRow) -> Text {
+        switch row {
+        case .interval: Text("Slideshow interval")
+        case .toggleStats: Text("Nerd stats")
+        }
+    }
+
+    /// The current value of an options row, read from the observable mirrors so it updates live.
+    /// The interval is flanked by ‹ › to show it's adjusted with left/right; nerd stats is a
+    /// switch flipped with the select button.
+    @ViewBuilder
+    private func optionRowValue(_ row: SlideshowViewModel.OptionRow) -> some View {
+        switch row {
+        case .interval:
+            HStack(spacing: 12) {
+                Text("‹").foregroundColor(.white.opacity(0.4))
+                Text("\(viewModel.displayInterval)s").foregroundColor(.white.opacity(0.85))
+                Text("›").foregroundColor(.white.opacity(0.4))
+            }
+        case .toggleStats:
+            Capsule()
+                .fill(viewModel.showVideoStats ? Color.green : Color.white.opacity(0.25))
+                .frame(width: 50, height: 28)
+                .overlay(
+                    Circle().fill(.white).padding(3),
+                    alignment: viewModel.showVideoStats ? .trailing : .leading
+                )
+        }
+    }
+
+    private func statLine(_ label: String, _ value: String) -> some View {
+        HStack(spacing: 8) {
+            Text(label).foregroundColor(.green.opacity(0.6))
+            Text(value)
+        }
+    }
+
+    /// What a left/right press moves to, for the scrubber hints.
+    private func assetActionLabel(_ action: SlideshowAction) -> String {
+        action == .goToNext ? "Next asset" : "Previous asset"
+    }
+
+    /// Formats seconds as `m:ss` (or `h:mm:ss`) for the scrubber.
+    static func timeLabel(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "0:00" }
+        let total = Int(seconds)
+        let secs = total % 60
+        let mins = (total / 60) % 60
+        let hours = total / 3600
+        return hours > 0
+            ? String(format: "%d:%02d:%02d", hours, mins, secs)
+            : String(format: "%d:%02d", mins, secs)
+    }
+
+    /// Formats a bits/second value as Mbps/kbps for the stats overlay.
+    static func bitrateLabel(_ bitsPerSecond: Double) -> String {
+        guard bitsPerSecond > 0 else { return "—" }
+        if bitsPerSecond >= 1_000_000 {
+            return String(format: "%.1f Mbps", bitsPerSecond / 1_000_000)
+        }
+        return String(format: "%.0f kbps", bitsPerSecond / 1000)
     }
 
     private var messagesOverlay: some View {

--- a/app/BigImmich/Slideshow/SlideshowViewModel.swift
+++ b/app/BigImmich/Slideshow/SlideshowViewModel.swift
@@ -582,19 +582,30 @@ final class SlideshowViewModel {
         return items[optionsMenuIndex]
     }
 
-    /// Left/right on the highlighted row: only the interval is a left/right value (clamped at the
-    /// ends). The nerd-stats toggle ignores left/right — it flips with the select button.
+    /// Left/right on the highlighted row: the interval steps (clamped at the ends), and the
+    /// nerd-stats row flips too. Off-centre touchpad clicks land as a directional press rather than
+    /// a select, so honouring left/right here is what makes the toggle reliable to flip.
     private func adjustCurrentOption(_ direction: MoveCommandDirection) {
-        guard case .interval = currentOptionRow() else { return }
-        let value = displayInterval + (direction == .right ? 1 : -1)
-        let clamped = min(max(value, 1), 60)
-        settings.slideshowInterval = clamped
-        displayInterval = clamped
+        switch currentOptionRow() {
+        case .interval:
+            let value = displayInterval + (direction == .right ? 1 : -1)
+            let clamped = min(max(value, 1), 60)
+            settings.slideshowInterval = clamped
+            displayInterval = clamped
+        case .toggleStats:
+            toggleVideoStats()
+        case .none:
+            break
+        }
     }
 
     /// The select (middle) button flips the nerd-stats toggle.
     func handleSelect() {
         guard showOptionsMenu, case .toggleStats = currentOptionRow() else { return }
+        toggleVideoStats()
+    }
+
+    private func toggleVideoStats() {
         showVideoStats.toggle()
         settings.slideshowShowVideoStats = showVideoStats
         if showVideoStats {

--- a/app/BigImmich/Slideshow/SlideshowViewModel.swift
+++ b/app/BigImmich/Slideshow/SlideshowViewModel.swift
@@ -11,6 +11,9 @@ final class SlideshowViewModel {
     let initialAssetID: AssetID?
 
     var slideshowAsset: SlideshowAsset?
+    /// The full asset (with complete EXIF: dimensions, size, file name) fetched for the nerd-stats
+    /// overlay — the album/search response's EXIF is partial. `nil` until fetched.
+    var detailedAsset: AlbumAsset?
 
     var userAssetIndex: Int = 0
     var userAssetsCount: Int = 0
@@ -20,6 +23,7 @@ final class SlideshowViewModel {
     var currentImage: Image?
     var currentPlayer: AVPlayer?
     var videoState: VideoState = .loading
+    var videoStats = VideoStats()
 
     var isLoading = false
     var errors: [String] = []
@@ -28,6 +32,27 @@ final class SlideshowViewModel {
     var slideshowIsRunning = true
     var showAssetDetails = false
     var assetProgress: Double = 0.0
+
+    /// On-screen options overlay (up button): `optionsMenuIndex` is the highlighted row into
+    /// `optionsMenuItems` (interval for photos, the nerd-stats toggle for videos).
+    var showOptionsMenu = false
+    var optionsMenuIndex = 0
+    /// Whether the "nerd stats" overlay is visible. Toggled from the options menu; seeded from
+    /// (and persisted back to) settings so a preference survives across launches.
+    var showVideoStats = false
+    /// Observable mirror of the slideshow interval shown live in the options overlay. `settings`
+    /// is `@ObservationIgnored`, so the overlay reads this to re-render when the value changes.
+    var displayInterval = 5
+    /// A short-lived "peek" of the video progress bar while playing (the down button). Ignored
+    /// while paused, where the bar is shown permanently.
+    var scrubberPeek = false
+    @ObservationIgnored private var scrubberPeekTimer: Timer?
+
+    /// When the user last pressed left/right while scrubbing a paused video. Used to require a
+    /// short quiet gap before a press at the very start/end changes the asset — so overshooting
+    /// to a boundary and holding there doesn't accidentally skip to the previous/next asset.
+    @ObservationIgnored private var lastScrubInstant: ContinuousClock.Instant?
+    private static let scrubBoundaryGrace: Duration = .seconds(1.2)
 
     @ObservationIgnored let settings = SlideshowSettings()
 
@@ -68,22 +93,35 @@ final class SlideshowViewModel {
             immichClient: immichClient,
             cacheCountLimit: 10
         )
+        showVideoStats = settings.slideshowShowVideoStats
         videoController.onProgress = { [weak self] progress in
             self?.assetProgress = progress
         }
         videoController.onStateChange = { [weak self] state in
             guard let self else { return }
             videoState = state
+            // `.buffering`/`.loading` are patient states — we wait for the buffer, never skip.
+            // Only a real failure advances the slideshow.
             if case let .failed(message) = state {
                 showError(message)
                 Task { await self.moveToNext() }
             }
         }
+        videoController.onStatsChange = { [weak self] stats in
+            self?.videoStats = stats
+        }
     }
 
     func start() async {
         isStopped = false
+        syncOverlayMirrors()
         await initSlideshow()
+    }
+
+    /// Refreshes the observable mirrors from the persisted settings (see their declaration).
+    private func syncOverlayMirrors() {
+        showVideoStats = settings.slideshowShowVideoStats
+        displayInterval = settings.slideshowInterval
     }
 
     func stop() {
@@ -91,6 +129,7 @@ final class SlideshowViewModel {
         stopSlideshowTimer()
         stopProgressBarTimer()
         stopCurrentPlayer()
+        cancelScrubberPeek()
         prewarmedVideo = nil
         // The in-memory image cache only serves this session; drop it on exit rather than
         // key it by rendition size. Cheap to rebuild — the on-disk cache backs the next run.
@@ -149,6 +188,53 @@ final class SlideshowViewModel {
     }
 
     func handleMoveCommand(_ direction: MoveCommandDirection) async {
+        // The options overlay captures the remote while it's open: up/down navigate rows,
+        // left/right adjust the highlighted row's value.
+        if showOptionsMenu {
+            switch direction {
+            case .up, .down: moveOptionsMenu(direction)
+            case .left, .right: adjustCurrentOption(direction)
+            default: break
+            }
+            return
+        }
+
+        // Up always opens the options overlay (over a photo or video), pausing playback.
+        if direction == .up, currentImage != nil || currentPlayer != nil {
+            openOptionsMenu()
+            return
+        }
+        // Down peeks the video progress bar: a couple of seconds while playing, or permanently
+        // while paused. It never hides the bar.
+        if direction == .down, currentPlayer != nil {
+            peekScrubber()
+            return
+        }
+
+        // Whenever the video progress bar is on screen (paused, or a down-button peek), left/right
+        // scrub — so a peek makes scrubbing available even while playing. The bar being hidden is
+        // what keeps left/right on changing assets. At the very start/end a press falls through to
+        // prev/next asset, but only after a short quiet gap so overshooting to a boundary stays put.
+        if showVideoScrubber, direction == .left || direction == .right {
+            let forward = direction == .right
+            let pastBoundary = (forward && videoAtEnd) || (!forward && videoAtStart)
+            let now = ContinuousClock.now
+            if !pastBoundary {
+                scrubVideo(forward: forward)
+                lastScrubInstant = now
+                // Scrubbing during a peek keeps the bar up (no-op while paused).
+                peekScrubber()
+                return
+            }
+            // At the boundary: absorb the press if the user is still actively pressing (keeps
+            // the timer alive); only a press after the grace period changes the asset.
+            if let last = lastScrubInstant, now - last < Self.scrubBoundaryGrace {
+                lastScrubInstant = now
+                return
+            }
+            lastScrubInstant = nil
+        }
+
         switch direction {
         case .left:
             stopSlideshowTimer()
@@ -170,15 +256,8 @@ final class SlideshowViewModel {
             case .goToPrevious:
                 await moveToPrevious()
             }
-        case .up:
-            if currentPlayer != nil {
-                videoController.seek(seconds: 15)
-            }
-        case .down:
-            if currentPlayer != nil {
-                videoController.seek(seconds: -15)
-            }
         default:
+            // Up/down are unused during playback — pause and scrub with left/right instead.
             break
         }
     }
@@ -188,9 +267,41 @@ final class SlideshowViewModel {
             slideshowIsRunning.toggle()
         }
         applyPlaybackState()
+        // Pausing shows the bar permanently; resuming hides it — either way the peek is moot.
+        cancelScrubberPeek()
         if !slideshowIsRunning {
             showAssetDetails = true
         }
+    }
+
+    /// The video progress bar is shown whenever a video is paused (permanently, regardless of how
+    /// it was paused or for how long), or briefly while playing after the down button (a peek).
+    /// Hidden while the options overlay is up. (Left/right only scrubs while paused — see above.)
+    var showVideoScrubber: Bool {
+        guard currentPlayer != nil, !showOptionsMenu else { return false }
+        return !slideshowIsRunning || scrubberPeek
+    }
+
+    /// The down button: peek the progress bar. While paused it's already shown permanently, so
+    /// this only matters while playing — show it, then auto-hide after a couple of seconds
+    /// (pressing again restarts the timer). Never hides the bar itself.
+    func peekScrubber() {
+        guard currentPlayer != nil, slideshowIsRunning else { return }
+        scrubberPeek = true
+        scrubberPeekTimer?.invalidate()
+        scrubberPeekTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                withAnimation { self.scrubberPeek = false }
+                self.scrubberPeekTimer = nil
+            }
+        }
+    }
+
+    private func cancelScrubberPeek() {
+        scrubberPeekTimer?.invalidate()
+        scrubberPeekTimer = nil
+        scrubberPeek = false
     }
 
     /// Applies the current `slideshowIsRunning` state to whatever asset is showing, so a paused
@@ -213,6 +324,60 @@ final class SlideshowViewModel {
         }
     }
 
+    /// Seconds of the current video, for the scrubber label. 0 for photos / unknown.
+    var videoDurationSeconds: Double {
+        videoController.durationSeconds
+    }
+
+    /// Current playhead position of the video in seconds.
+    var videoCurrentSeconds: Double {
+        videoController.currentSeconds
+    }
+
+    /// Whether the video is at its very start / end. Uses the optimistic `assetProgress` bar so
+    /// the boundary — and therefore the scrubber hints — update the instant you scrub, in lockstep
+    /// with the bar and the time label.
+    var videoAtStart: Bool {
+        assetProgress <= 0.001
+    }
+
+    var videoAtEnd: Bool {
+        assetProgress >= 0.999
+    }
+
+    /// The current playhead in seconds to *show* on the scrubber: derived from the bar position so
+    /// it tracks scrubbing immediately (the player's own time lags a paused seek).
+    var videoDisplaySeconds: Double {
+        videoController.durationSeconds * assetProgress
+    }
+
+    /// The per-press scrub step (seconds) for the current video, shown in the scrubber hints.
+    var videoScrubStepSeconds: Int {
+        Int(Self.scrubStep(forDuration: videoController.durationSeconds))
+    }
+
+    /// Seeks one scrub step (scaled to the video's length) and reflects it in the progress bar
+    /// immediately, so scrubbing feels responsive even while paused (when the time observer is
+    /// idle). Short clips step finely; long ones step coarsely so you can traverse them quickly.
+    private func scrubVideo(forward: Bool) {
+        let duration = videoController.durationSeconds
+        let delta = (forward ? 1.0 : -1.0) * Self.scrubStep(forDuration: duration)
+        videoController.seek(seconds: delta)
+        guard duration > 0 else { return }
+        assetProgress = min(max(assetProgress + delta / duration, 0), 1)
+    }
+
+    /// The per-press scrub step for a video of the given length.
+    private static func scrubStep(forDuration duration: Double) -> Double {
+        switch duration {
+        case ..<20: 2 // ≤20s clips: 2s taps
+        case ..<60: 5 // ≤1min: 5s
+        case ..<300: 15 // ≤5min: 15s
+        case ..<1200: 30 // ≤20min: 30s
+        default: 60 // longer: 1min
+        }
+    }
+
     private func loadAssetMetadata(for assetID: AssetID) {
         let client = immichClient
         Task { [weak self] in
@@ -220,9 +385,17 @@ final class SlideshowViewModel {
             else { return }
 
             guard let self, slideshowAsset?.asset.id == assetID else { return }
+            detailedAsset = detailed
             userDateTime = formattedCaptureDate(detailed)
             userLocation = formattedLocation(detailed)
         }
+    }
+
+    /// Ensures the full asset (with complete EXIF) is loaded, e.g. when the stats overlay is
+    /// switched on for the current photo.
+    func loadDetailedAssetIfNeeded() {
+        guard detailedAsset == nil, let assetID = slideshowAsset?.asset.id else { return }
+        loadAssetMetadata(for: assetID)
     }
 
     private func loadCurrentAsset(slideshowAsset: SlideshowAsset) async {
@@ -245,15 +418,20 @@ final class SlideshowViewModel {
         currentImage = nil
         currentPlayer = nil
         assetProgress = 0.0
+        detailedAsset = nil
+        // Per-asset UI state resets so nothing leaks across a transition.
+        showOptionsMenu = false
+        cancelScrubberPeek()
+        lastScrubInstant = nil
 
         userAssetIndex = slideshowAsset.counter.current
         userAssetsCount = slideshowAsset.counter.total
         userDateTime = formattedCaptureDate(asset)
         userLocation = formattedLocation(asset)
-        // The album/search response already carries EXIF, so only fetch the full
-        // asset when it's missing (e.g. a Top Shelf deep link) — saves one network
-        // round-trip per photo, which matters on a slow connection.
-        if asset.exifInfo == nil {
+        // The album/search response carries partial EXIF, so fetch the full asset when it's
+        // missing (e.g. a Top Shelf deep link) or when the nerd-stats overlay needs the complete
+        // metadata (dimensions/size). Otherwise skip it — a round-trip that matters on a slow link.
+        if asset.exifInfo == nil || showVideoStats {
             loadAssetMetadata(for: asset.id)
         }
 
@@ -277,30 +455,26 @@ final class SlideshowViewModel {
         } else if asset.assetType == .video {
             let urlAsset: AVURLAsset
             if let prewarmed = prewarmedVideo, prewarmed.id == asset.id {
-                urlAsset = prewarmed.asset
                 prewarmedVideo = nil
+                urlAsset = prewarmed.asset
+            } else if let url = try? await immichClient.videoPlaybackURL(assetID: asset.id) {
+                urlAsset = AVURLAsset(url: url)
             } else {
-                do {
-                    let playbackURL = try await immichClient.videoPlaybackURL(
-                        assetID: asset.id
-                    )
-                    urlAsset = AVURLAsset(url: playbackURL)
-                } catch {
-                    showError(
-                        "loading video failed: failed to construct playback URL"
-                    )
-                    return
-                }
+                showError("loading video failed: failed to construct playback URL")
+                return
             }
 
             videoController.start(
                 asset: urlAsset,
                 autoplay: slideshowIsRunning,
+                forwardBufferDuration: 30,
                 onEnded: { [weak self] in
                     Task { await self?.moveToNext() }
                 }
             )
             currentPlayer = videoController.player
+            // A video that loads while the slideshow is paused (e.g. navigated to from a paused
+            // asset) shows its progress bar automatically via `showVideoScrubber`.
         }
 
         if previousAlbumID != slideshowAsset.album.id {
@@ -345,6 +519,86 @@ final class SlideshowViewModel {
             )
         } catch {
             logError(error)
+        }
+    }
+
+    /// A row in the in-slideshow options overlay (opened with the up button). Photos show the
+    /// interval; videos show the nerd-stats toggle. Adjusted with left/right (or select).
+    enum OptionRow: Identifiable, Equatable {
+        case interval
+        case toggleStats
+
+        var id: String {
+            switch self {
+            case .interval: "interval"
+            case .toggleStats: "stats"
+            }
+        }
+    }
+
+    var optionsMenuItems: [OptionRow] {
+        if currentPlayer != nil {
+            return [.toggleStats]
+        }
+        if currentImage != nil {
+            return [.interval, .toggleStats]
+        }
+        return []
+    }
+
+    /// Opens the options overlay over the current asset, always pausing playback — while it's
+    /// open you can only change settings; closing it resumes the slideshow.
+    func openOptionsMenu() {
+        guard currentImage != nil || currentPlayer != nil else { return }
+        slideshowIsRunning = false
+        applyPlaybackState()
+        cancelScrubberPeek()
+        optionsMenuIndex = 0
+        withAnimation { showOptionsMenu = true }
+    }
+
+    /// Closes the overlay and resumes the slideshow — the same as pressing play. For a photo this
+    /// restarts its interval from zero; a video resumes from where it was.
+    func closeOptionsMenu() {
+        withAnimation { showOptionsMenu = false }
+        slideshowIsRunning = true
+        applyPlaybackState()
+    }
+
+    /// Moves the menu highlight up/down (clamped at the ends).
+    func moveOptionsMenu(_ direction: MoveCommandDirection) {
+        let count = optionsMenuItems.count
+        guard count > 0 else { return }
+        switch direction {
+        case .up: optionsMenuIndex = max(0, optionsMenuIndex - 1)
+        case .down: optionsMenuIndex = min(count - 1, optionsMenuIndex + 1)
+        default: break
+        }
+    }
+
+    private func currentOptionRow() -> OptionRow? {
+        let items = optionsMenuItems
+        guard items.indices.contains(optionsMenuIndex) else { return nil }
+        return items[optionsMenuIndex]
+    }
+
+    /// Left/right on the highlighted row: only the interval is a left/right value (clamped at the
+    /// ends). The nerd-stats toggle ignores left/right — it flips with the select button.
+    private func adjustCurrentOption(_ direction: MoveCommandDirection) {
+        guard case .interval = currentOptionRow() else { return }
+        let value = displayInterval + (direction == .right ? 1 : -1)
+        let clamped = min(max(value, 1), 60)
+        settings.slideshowInterval = clamped
+        displayInterval = clamped
+    }
+
+    /// The select (middle) button flips the nerd-stats toggle.
+    func handleSelect() {
+        guard showOptionsMenu, case .toggleStats = currentOptionRow() else { return }
+        showVideoStats.toggle()
+        settings.slideshowShowVideoStats = showVideoStats
+        if showVideoStats {
+            loadDetailedAssetIfNeeded()
         }
     }
 

--- a/app/BigImmich/Slideshow/VideoPlaybackController.swift
+++ b/app/BigImmich/Slideshow/VideoPlaybackController.swift
@@ -3,53 +3,133 @@ import ImmichAPI
 
 /// Observed playback state of the current video, derived from `AVPlayer`/`AVPlayerItem`.
 enum VideoState: Equatable {
-    /// Buffering or waiting to start (`timeControlStatus == .waitingToPlayAtSpecifiedRate`).
+    /// Loading the very first data — nothing has played yet.
     case loading
+    /// Playback started but is now waiting for the buffer to refill (a mid-stream stall).
+    /// Distinct from `loading` so the UI can say "buffering…" rather than restarting.
+    case buffering
     case playing
     case paused
-    /// The item failed to load, or never started within the stall window.
+    /// The item failed to load, or the buffer stopped advancing for so long we treat it as dead.
     case failed(String)
 }
 
+/// Live playback statistics for the optional "nerd stats" overlay. All values are best-effort
+/// reads from `AVPlayerItem`'s access log and current item; zero/`nil` when not yet known.
+struct VideoStats: Equatable {
+    /// Bitrate the server declares for the current variant (bits/s); 0 when unknown.
+    var indicatedBitrate: Double = 0
+    /// Throughput actually observed while downloading (bits/s); 0 when unknown.
+    var observedBitrate: Double = 0
+    /// Decoded frame size of the current rendition.
+    var resolution: CGSize = .zero
+    /// Number of playback stalls since the item started.
+    var stalls: Int = 0
+    /// Seconds of media buffered ahead of the playhead.
+    var bufferedAhead: Double = 0
+    /// Human label for the active quality (e.g. "1080p" or "Auto"), set by the caller.
+    var variant: String?
+    /// Video codec of the source track (e.g. "H.264", "HEVC"); empty until loaded.
+    var codec: String = ""
+    /// Nominal frame rate of the source track; 0 until loaded.
+    var frameRate: Float = 0
+    /// Colour primaries of the source track (e.g. "BT.709", "BT.2020"); empty until loaded.
+    var colorSpace: String = ""
+}
+
 /// Owns the `AVPlayer` for the currently playing video: its lifecycle, the play-to-end and
-/// periodic-time observers, seeking, and playback state.
+/// periodic-time observers, seeking, buffering detection, playback state and live stats.
 ///
 /// Playback state is read from the player itself — `AVPlayerItem.status` (real load failures,
-/// with the underlying error) and `AVPlayer.timeControlStatus` (playing / paused / buffering)
-/// — instead of guessing with a fixed timer. A single generous stall guard still advances a
-/// stream that never fails but also never starts. Every observer added here is torn down in
-/// `stop()`. Everything runs on the main actor; KVO callbacks hop to it since AVFoundation may
-/// deliver them off the main thread.
+/// with the underlying error) and `AVPlayer.timeControlStatus` (playing / waiting / paused) —
+/// and `waitingToPlayAtSpecifiedRate` is reported as `buffering` once playback has begun so a
+/// slow link shows a spinner instead of skipping the video. A watchdog only fails a stream
+/// whose buffer stops growing for a long window, so "willing to wait" links keep buffering.
+/// Every observer added here is torn down in `stop()`. Everything runs on the main actor; KVO
+/// callbacks hop to it since AVFoundation may deliver them off the main thread.
 @MainActor
 final class VideoPlaybackController {
-    private static let stallTimeout: Duration = .seconds(15)
+    /// How long the buffer may make no forward progress (while we're trying to play) before we
+    /// give up. Generous on purpose: the design goal is to wait for quality, not to bail early.
+    private static let stuckTimeout: Duration = .seconds(45)
 
     private(set) var player: AVPlayer?
     private(set) var state: VideoState = .loading
 
     private var endObserver: NSObjectProtocol?
+    private var stalledObserver: NSObjectProtocol?
     private var timeObserverToken: Any?
     private var statusObservation: NSKeyValueObservation?
     private var timeControlObservation: NSKeyValueObservation?
-    private var stallGuard: Task<Void, Never>?
+    private var likelyToKeepUpObservation: NSKeyValueObservation?
+    private var bufferEmptyObservation: NSKeyValueObservation?
+    private var watchdog: Task<Void, Never>?
+
+    /// Whether playback has produced frames at least once, so we can tell a first-load
+    /// (`loading`) apart from a mid-stream rebuffer (`buffering`).
+    private var hasStartedPlaying = false
+    /// A start position to seek to once the item is ready (used when switching quality so the
+    /// new rendition resumes where the old one was). 0 means start from the beginning.
+    private var pendingStartSeconds: Double = 0
+    /// Label for the active quality, surfaced in the stats overlay.
+    private var variantLabel: String?
+    /// Source-track details (codec / fps / colour) loaded asynchronously for the stats overlay.
+    private var trackCodec = ""
+    private var trackFrameRate: Float = 0
+    private var trackColorSpace = ""
 
     /// Called with playback progress in `0...1` as the video advances.
     var onProgress: ((Double) -> Void)?
     /// Called whenever the derived `state` changes.
     var onStateChange: ((VideoState) -> Void)?
+    /// Called ~once a second with fresh playback statistics.
+    var onStatsChange: ((VideoStats) -> Void)?
 
-    /// Starts loading `url`, wiring up state observation and the end-of-item callback.
+    /// Total duration of the current item in seconds, or 0 when unknown.
+    var durationSeconds: Double {
+        guard let seconds = player?.currentItem?.duration.seconds, seconds.isFinite, seconds > 0 else { return 0 }
+        return seconds
+    }
+
+    /// Current playhead position in seconds.
+    var currentSeconds: Double {
+        player?.currentTime().seconds ?? 0
+    }
+
+    /// Starts loading `asset`, wiring up state observation, buffering detection and the
+    /// end-of-item callback.
     /// - Parameters:
     ///   - autoplay: when `false` the video is loaded paused (the slideshow is paused).
+    ///   - forwardBufferDuration: seconds of media to buffer ahead; 0 leaves the system default.
+    ///   - maxBitrate: cap on selected bitrate (bits/s); 0 is unlimited.
+    ///   - variantLabel: quality label for the stats overlay.
     ///   - onEnded: called when the item plays to the end.
     func start(
         asset: AVURLAsset,
         autoplay: Bool,
+        forwardBufferDuration: Double = 30,
+        maxBitrate: Double = 0,
+        startAtSeconds: Double = 0,
+        variantLabel: String? = nil,
         onEnded: @escaping () -> Void
     ) {
         stop()
+        hasStartedPlaying = false
+        pendingStartSeconds = startAtSeconds
+        self.variantLabel = variantLabel
+        trackCodec = ""
+        trackFrameRate = 0
+        trackColorSpace = ""
+        loadTrackInfo(from: asset)
 
         let playerItem = AVPlayerItem(asset: asset)
+        if forwardBufferDuration > 0 {
+            playerItem.preferredForwardBufferDuration = forwardBufferDuration
+        }
+        if maxBitrate > 0 {
+            playerItem.preferredPeakBitRate = maxBitrate
+        }
+
         let player = AVPlayer(playerItem: playerItem)
         // Prefer building a buffer over starting instantly, so brief network dips don't stall.
         player.automaticallyWaitsToMinimizeStalling = true
@@ -57,11 +137,11 @@ final class VideoPlaybackController {
 
         observeStatus(of: playerItem)
         observeTimeControl(of: player)
+        observeBuffering(of: playerItem)
         observeProgress()
 
         if autoplay {
             player.play()
-            scheduleStallGuard(for: player)
         }
 
         endObserver = NotificationCenter.default.addObserver(
@@ -71,7 +151,15 @@ final class VideoPlaybackController {
         ) { _ in
             onEnded()
         }
+        stalledObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemPlaybackStalled,
+            object: playerItem,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { self?.refreshState() }
+        }
 
+        startWatchdog(for: player)
         refreshState()
     }
 
@@ -80,67 +168,112 @@ final class VideoPlaybackController {
         guard let player else { return }
         player.play()
         observeProgress()
-        scheduleStallGuard(for: player)
+        startWatchdog(for: player)
         refreshState()
     }
 
     /// Pauses playback.
     func pause() {
         player?.pause()
-        stallGuard?.cancel()
-        stallGuard = nil
+        watchdog?.cancel()
+        watchdog = nil
         refreshState()
     }
 
+    /// Seeks by a relative number of seconds. Uses zero tolerance so the jump is exactly the
+    /// requested amount — the default seek snaps to the nearest keyframe, which for sparse-keyframe
+    /// videos lands several seconds off (a "5s" step actually moving 8–9s).
     func seek(seconds: Double) {
         guard let player, let currentItem = player.currentItem else { return }
         let currentTime = player.currentTime()
         let newTime = CMTimeAdd(
             currentTime,
-            CMTimeMakeWithSeconds(
-                seconds,
-                preferredTimescale: currentTime.timescale
-            )
+            CMTimeMakeWithSeconds(seconds, preferredTimescale: 600)
         )
 
-        let clampedTime: CMTime
-        if CMTimeCompare(newTime, .zero) < 0 {
-            clampedTime = .zero
-        } else if CMTimeCompare(newTime, currentItem.duration) > 0 {
-            return
+        let clampedTime: CMTime = if CMTimeCompare(newTime, .zero) < 0 {
+            .zero
+        } else if currentItem.duration.isNumeric, CMTimeCompare(newTime, currentItem.duration) > 0 {
+            currentItem.duration
         } else {
-            clampedTime = newTime
+            newTime
         }
 
-        player.seek(to: clampedTime)
+        player.seek(to: clampedTime, toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    /// Seeks to an absolute fraction `0...1` of the duration (used by the scrubber).
+    func seek(toFraction fraction: Double) {
+        guard let player, durationSeconds > 0 else { return }
+        let clamped = min(max(fraction, 0), 1)
+        let target = CMTimeMakeWithSeconds(
+            durationSeconds * clamped,
+            preferredTimescale: 600
+        )
+        player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
     }
 
     func stop() {
-        stallGuard?.cancel()
-        stallGuard = nil
+        watchdog?.cancel()
+        watchdog = nil
         statusObservation?.invalidate()
         statusObservation = nil
         timeControlObservation?.invalidate()
         timeControlObservation = nil
+        likelyToKeepUpObservation?.invalidate()
+        likelyToKeepUpObservation = nil
+        bufferEmptyObservation?.invalidate()
+        bufferEmptyObservation = nil
         removeTimeObserver()
         if let endObserver {
             NotificationCenter.default.removeObserver(endObserver)
             self.endObserver = nil
         }
+        if let stalledObserver {
+            NotificationCenter.default.removeObserver(stalledObserver)
+            self.stalledObserver = nil
+        }
         player?.pause()
         player = nil
         state = .loading
+        hasStartedPlaying = false
+        pendingStartSeconds = 0
     }
 
     private func observeStatus(of item: AVPlayerItem) {
         statusObservation = item.observe(\.status) { [weak self] _, _ in
             guard let self else { return }
-            Task { @MainActor in self.refreshState() }
+            Task { @MainActor in
+                self.applyPendingStartIfReady()
+                self.refreshState()
+            }
         }
+    }
+
+    /// Once the item is ready to play, seek to any requested start position (a quality switch
+    /// resuming mid-video). Runs once — the position is cleared after seeking.
+    private func applyPendingStartIfReady() {
+        guard pendingStartSeconds > 0,
+              let player, player.currentItem?.status == .readyToPlay
+        else { return }
+        let target = CMTimeMakeWithSeconds(pendingStartSeconds, preferredTimescale: 600)
+        pendingStartSeconds = 0
+        player.seek(to: target, toleranceBefore: .zero, toleranceAfter: .zero)
     }
 
     private func observeTimeControl(of player: AVPlayer) {
         timeControlObservation = player.observe(\.timeControlStatus) { [weak self] _, _ in
+            guard let self else { return }
+            Task { @MainActor in self.refreshState() }
+        }
+    }
+
+    private func observeBuffering(of item: AVPlayerItem) {
+        likelyToKeepUpObservation = item.observe(\.isPlaybackLikelyToKeepUp) { [weak self] _, _ in
+            guard let self else { return }
+            Task { @MainActor in self.refreshState() }
+        }
+        bufferEmptyObservation = item.observe(\.isPlaybackBufferEmpty) { [weak self] _, _ in
             guard let self else { return }
             Task { @MainActor in self.refreshState() }
         }
@@ -164,28 +297,148 @@ final class VideoPlaybackController {
 
         switch player.timeControlStatus {
         case .playing:
+            hasStartedPlaying = true
             return .playing
         case .paused:
             return .paused
         case .waitingToPlayAtSpecifiedRate:
-            return .loading
+            // Once frames have shown, a wait is a mid-stream rebuffer; before that it's the
+            // initial load. Either way we keep waiting — the watchdog handles a dead stream.
+            return hasStartedPlaying ? .buffering : .loading
         @unknown default:
             return .loading
         }
     }
 
-    /// Fallback for a stream that never emits `.failed` but also never starts: after a generous
-    /// window, if we're still `.loading` (not paused, not playing), treat it as failed to start.
-    private func scheduleStallGuard(for player: AVPlayer) {
-        stallGuard?.cancel()
-        stallGuard = Task { [weak self] in
-            try? await Task.sleep(for: Self.stallTimeout)
-            guard let self, !Task.isCancelled, self.player === player else { return }
-            if state == .loading {
-                state = .failed("video did not start playing")
-                onStateChange?(state)
+    /// Samples the buffered lead and live stats once a second. Fails the item only when the
+    /// buffer makes no forward progress for `stuckTimeout` while we're trying to play — so a
+    /// merely-slow link keeps buffering rather than being skipped.
+    private func startWatchdog(for player: AVPlayer) {
+        watchdog?.cancel()
+        watchdog = Task { [weak self] in
+            var lastBufferedEnd = -1.0
+            var lastAdvance = ContinuousClock.now
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1))
+                guard let self, self.player === player, !Task.isCancelled else { return }
+
+                let bufferedEnd = bufferedEndSeconds()
+                emitStats(bufferedEnd: bufferedEnd)
+
+                if bufferedEnd > lastBufferedEnd + 0.01 {
+                    lastBufferedEnd = bufferedEnd
+                    lastAdvance = ContinuousClock.now
+                    continue
+                }
+
+                // No buffer progress this tick. A paused video legitimately makes none, and a
+                // playing one isn't stuck — only worry when we're trying to play but can't.
+                if case .failed = state {
+                    return
+                }
+                let trying = player.timeControlStatus != .paused
+                if trying,
+                   state != .playing,
+                   ContinuousClock.now - lastAdvance > Self.stuckTimeout
+                {
+                    state = .failed("video stalled: the connection is too slow to buffer")
+                    onStateChange?(state)
+                    return
+                }
             }
         }
+    }
+
+    /// The playhead-relative end of the currently buffered range, in absolute seconds.
+    private func bufferedEndSeconds() -> Double {
+        guard let item = player?.currentItem,
+              let range = item.loadedTimeRanges.first?.timeRangeValue
+        else { return 0 }
+        return (range.start + range.duration).seconds
+    }
+
+    private func emitStats(bufferedEnd: Double) {
+        guard let item = player?.currentItem else { return }
+        let event = item.accessLog()?.events.last
+        var stats = VideoStats()
+        stats.indicatedBitrate = max(event?.indicatedBitrate ?? 0, 0)
+        stats.observedBitrate = max(event?.observedBitrate ?? 0, 0)
+        stats.resolution = item.presentationSize
+        stats.stalls = max(event?.numberOfStalls ?? 0, 0)
+        stats.bufferedAhead = max(bufferedEnd - currentSeconds, 0)
+        stats.variant = variantLabel
+        stats.codec = trackCodec
+        stats.frameRate = trackFrameRate
+        stats.colorSpace = trackColorSpace
+        onStatsChange?(stats)
+    }
+
+    /// Loads the source video track's codec, frame rate and colour primaries off the main actor
+    /// and stores them for the stats overlay. Best-effort — leaves the fields empty on failure.
+    private func loadTrackInfo(from asset: AVURLAsset) {
+        Task { [weak self] in
+            guard let track = try? await asset.loadTracks(withMediaType: .video).first else { return }
+            let fps = await (try? track.load(.nominalFrameRate)) ?? 0
+            let descriptions = await (try? track.load(.formatDescriptions)) ?? []
+            guard let description = descriptions.first else {
+                await self?.applyTrackInfo(codec: "", frameRate: fps, colorSpace: "")
+                return
+            }
+            let codec = Self.codecName(CMFormatDescriptionGetMediaSubType(description))
+            let colorSpace = Self.colorPrimariesName(description)
+            await self?.applyTrackInfo(codec: codec, frameRate: fps, colorSpace: colorSpace)
+        }
+    }
+
+    private func applyTrackInfo(codec: String, frameRate: Float, colorSpace: String) {
+        trackCodec = codec
+        trackFrameRate = frameRate
+        trackColorSpace = colorSpace
+    }
+
+    private static func codecName(_ subType: FourCharCode) -> String {
+        switch subType {
+        case kCMVideoCodecType_H264: "H.264"
+        case kCMVideoCodecType_HEVC: "HEVC"
+        case kCMVideoCodecType_AV1: "AV1"
+        case kCMVideoCodecType_VP9: "VP9"
+        case kCMVideoCodecType_MPEG4Video: "MPEG-4"
+        default: fourCCString(subType)
+        }
+    }
+
+    private static func fourCCString(_ code: FourCharCode) -> String {
+        let bytes = [
+            UInt8((code >> 24) & 0xFF),
+            UInt8((code >> 16) & 0xFF),
+            UInt8((code >> 8) & 0xFF),
+            UInt8(code & 0xFF)
+        ]
+        let scalars = bytes.filter { $0 >= 32 && $0 < 127 }.map { Character(UnicodeScalar($0)) }
+        return scalars.isEmpty ? "?" : String(scalars)
+    }
+
+    private static func colorPrimariesName(_ description: CMFormatDescription) -> String {
+        guard let primaries = CMFormatDescriptionGetExtension(
+            description,
+            extensionKey: kCMFormatDescriptionExtension_ColorPrimaries
+        ) as? String else { return "" }
+        if primaries == kCMFormatDescriptionColorPrimaries_ITU_R_709_2 as String {
+            return "BT.709"
+        }
+        if primaries == kCMFormatDescriptionColorPrimaries_ITU_R_2020 as String {
+            return "BT.2020"
+        }
+        if primaries == kCMFormatDescriptionColorPrimaries_P3_D65 as String {
+            return "P3"
+        }
+        if primaries == kCMFormatDescriptionColorPrimaries_EBU_3213 as String {
+            return "EBU 3213"
+        }
+        if primaries == kCMFormatDescriptionColorPrimaries_SMPTE_C as String {
+            return "SMPTE-C"
+        }
+        return primaries
     }
 
     private func observeProgress() {

--- a/app/BigImmichTests/Slideshow/Fakers.swift
+++ b/app/BigImmichTests/Slideshow/Fakers.swift
@@ -70,6 +70,7 @@ struct FakeSettings: SlideshowSettingsProtocol {
     var slideshowShowProgressBar: SlideshowShowProgressBar = .always
     var slideshowImageQuality: SlideshowImageQuality = .fullsize
     var slideshowPreloadVideos: Bool = true
+    var slideshowShowVideoStats: Bool = false
 
     init(
         slideshowOnceEndedAction: SlideshowOnceEndedAction,

--- a/app/BigImmichUITests/SlideshowJourneyUITests.swift
+++ b/app/BigImmichUITests/SlideshowJourneyUITests.swift
@@ -94,29 +94,25 @@ final class SlideshowJourneyUITests: XCTestCase {
         add(attachment)
     }
 
-    /// Each credential field shows a compact "Add/Edit" button at rest and reveals a real text
-    /// field only while editing. So: focus the button (the tvOS focus engine only exposes
-    /// directional moves), Select to reveal the auto-focused field, Select again to enter
-    /// text-entry mode (a highlighted field still lacks *keyboard* focus until then), type via the
-    /// emulated hardware keyboard, and dismiss with Menu — which keeps the entered text.
+    /// Moves focus downward onto the field (the tvOS focus engine only exposes directional moves),
+    /// presses Select to enter text-entry mode (a highlighted field still lacks *keyboard* focus
+    /// until then), types via the emulated hardware keyboard, and dismisses the keyboard with Menu,
+    /// which keeps the entered text.
     private func typeCredential(_ text: String, fieldID: String, secure: Bool, in app: XCUIApplication) {
-        let button = app.buttons["\(fieldID)Button"]
-        XCTAssertTrue(button.waitForExistence(timeout: 10), "field button not found")
-
-        var focused = button.hasFocus
-        for _ in 0 ..< 12 where !focused {
-            XCUIRemote.shared.press(.down)
-            Thread.sleep(forTimeInterval: 0.3)
-            focused = button.hasFocus
-        }
-        XCTAssertTrue(focused, "could not focus the field button")
-
-        // Reveal the text field; it grabs focus as it appears.
-        XCUIRemote.shared.press(.select)
-        Thread.sleep(forTimeInterval: 0.8)
-
         let field = secure ? app.secureTextFields[fieldID] : app.textFields[fieldID]
-        XCTAssertTrue(field.waitForExistence(timeout: 5), "text field not found")
+        XCTAssertTrue(field.waitForExistence(timeout: 10), "text field not found")
+
+        // The redesigned settings puts a category sidebar on the left and the fields in a detail
+        // pane. Move Right off the sidebar into the pane (harmless if already there); entry lands on
+        // whichever control is nearest, so scan down and then up to settle on the target field.
+        if !field.hasFocus {
+            XCUIRemote.shared.press(.right)
+            Thread.sleep(forTimeInterval: 0.4)
+        }
+        if !focus(field, pressing: .down) {
+            _ = focus(field, pressing: .up)
+        }
+        XCTAssertTrue(field.hasFocus, "could not focus the text field")
 
         XCUIRemote.shared.press(.select)
         Thread.sleep(forTimeInterval: 1.0)
@@ -140,11 +136,13 @@ final class SlideshowJourneyUITests: XCTestCase {
         Thread.sleep(forTimeInterval: 0.5)
     }
 
-    /// Albums is the left-most segment.
+    /// Settings is now a full-page screen, so leave it with the Menu button — once from the detail
+    /// pane back to the sidebar, once more to exit to Albums.
     private func openAlbumsTab() {
-        press(.up, times: 4)
-        press(.left, times: 3)
-        Thread.sleep(forTimeInterval: 0.5)
+        XCUIRemote.shared.press(.menu)
+        Thread.sleep(forTimeInterval: 0.6)
+        XCUIRemote.shared.press(.menu)
+        Thread.sleep(forTimeInterval: 0.8)
     }
 
     private func openFirstAlbum() {

--- a/app/BigImmichUITests/SlideshowJourneyUITests.swift
+++ b/app/BigImmichUITests/SlideshowJourneyUITests.swift
@@ -43,8 +43,8 @@ final class SlideshowJourneyUITests: XCTestCase {
 
         // 3. Type the mock-server credentials into the Settings form, exactly as
         //    a user would, and wait for the connection test to pass.
-        typeCredential(mockURL, into: app.textFields["immichURLField"])
-        typeCredential(apiKey, into: app.secureTextFields["apiKeyField"])
+        typeCredential(mockURL, fieldID: "immichURLField", secure: false, in: app)
+        typeCredential(apiKey, fieldID: "apiKeyField", secure: true, in: app)
         XCTAssertTrue(
             app.staticTexts["Connection to Immich works!"].waitForExistence(timeout: 20),
             "expected a working connection to the mock server"
@@ -94,25 +94,33 @@ final class SlideshowJourneyUITests: XCTestCase {
         add(attachment)
     }
 
-    /// Moves focus downward onto the given field (the tvOS focus engine only
-    /// exposes directional moves), presses Select to enter text-entry mode
-    /// (on tvOS a highlighted field still lacks *keyboard* focus until then),
-    /// types via the emulated hardware keyboard, and dismisses the keyboard
-    /// with Menu, which keeps the entered text.
-    private func typeCredential(_ text: String, into field: XCUIElement) {
-        XCTAssertTrue(field.waitForExistence(timeout: 10), "text field not found")
+    /// Each credential field shows a compact "Add/Edit" button at rest and reveals a real text
+    /// field only while editing. So: focus the button (the tvOS focus engine only exposes
+    /// directional moves), Select to reveal the auto-focused field, Select again to enter
+    /// text-entry mode (a highlighted field still lacks *keyboard* focus until then), type via the
+    /// emulated hardware keyboard, and dismiss with Menu — which keeps the entered text.
+    private func typeCredential(_ text: String, fieldID: String, secure: Bool, in app: XCUIApplication) {
+        let button = app.buttons["\(fieldID)Button"]
+        XCTAssertTrue(button.waitForExistence(timeout: 10), "field button not found")
 
-        var focused = field.hasFocus
+        var focused = button.hasFocus
         for _ in 0 ..< 12 where !focused {
             XCUIRemote.shared.press(.down)
             Thread.sleep(forTimeInterval: 0.3)
-            focused = field.hasFocus
+            focused = button.hasFocus
         }
-        XCTAssertTrue(focused, "could not focus the text field")
+        XCTAssertTrue(focused, "could not focus the field button")
+
+        // Reveal the text field; it grabs focus as it appears.
+        XCUIRemote.shared.press(.select)
+        Thread.sleep(forTimeInterval: 0.8)
+
+        let field = secure ? app.secureTextFields[fieldID] : app.textFields[fieldID]
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "text field not found")
 
         XCUIRemote.shared.press(.select)
         Thread.sleep(forTimeInterval: 1.0)
-        XCUIApplication().typeText(text)
+        app.typeText(text)
         Thread.sleep(forTimeInterval: 0.5)
         XCUIRemote.shared.press(.menu)
         Thread.sleep(forTimeInterval: 0.8)

--- a/app/ImmichAPI/Album.swift
+++ b/app/ImmichAPI/Album.swift
@@ -72,12 +72,14 @@ public struct AlbumAsset: Codable, Identifiable {
     public let id: AssetID
     public let type: String
     public let durationMilliseconds: Int?
+    public let originalFileName: String?
     public let exifInfo: ExifInfo?
 
     enum CodingKeys: String, CodingKey {
         case id
         case type
         case exifInfo
+        case originalFileName
         case durationMilliseconds = "duration"
     }
 
@@ -85,11 +87,13 @@ public struct AlbumAsset: Codable, Identifiable {
         id: AssetID,
         type: String,
         durationMilliseconds: Int?,
+        originalFileName: String? = nil,
         exifInfo: ExifInfo? = nil
     ) {
         self.id = id
         self.type = type
         self.durationMilliseconds = durationMilliseconds
+        self.originalFileName = originalFileName
         self.exifInfo = exifInfo
     }
 
@@ -107,11 +111,25 @@ public struct ExifInfo: Codable {
     public let city: String?
     public let state: String?
     public let country: String?
+    public let exifImageWidth: Int?
+    public let exifImageHeight: Int?
+    public let fileSizeInByte: Int?
 
-    public init(dateTimeOriginal: String?, city: String?, state: String?, country: String?) {
+    public init(
+        dateTimeOriginal: String?,
+        city: String?,
+        state: String?,
+        country: String?,
+        exifImageWidth: Int? = nil,
+        exifImageHeight: Int? = nil,
+        fileSizeInByte: Int? = nil
+    ) {
         self.dateTimeOriginal = dateTimeOriginal
         self.city = city
         self.state = state
         self.country = country
+        self.exifImageWidth = exifImageWidth
+        self.exifImageHeight = exifImageHeight
+        self.fileSizeInByte = fileSizeInByte
     }
 }


### PR DESCRIPTION
## Settings
- Full-page sidebar settings screen (Connection, Slideshow, Controls, Performance, Diagnostics, About), replacing the long scrolling view.
- **Controls page**: a full-height Siri Remote graphic with every action listed beside it; focusing a row highlights the matching control on the remote. Left/Right are configurable dropdowns, the rest are described.
- Slide interval is now a dropdown (1–10s, then 12/15/20s, then every 5s to 60s); dropdown values are sentence-case.
- Plain, normal text-entry fields; the paste tip moved below the connection card and adapts to API key vs password.
- Sentry is opt-in with a user-supplied DSN (personal DSN removed).

## Slideshow playback
- Buffering detection and a zero-growth watchdog; duration-scaled scrubbing with zero-tolerance seeks.
- In-slideshow options overlay, down-button progress-bar peek, paused scrubber with left/right hints, and richer nerd stats (codec, frame rate, colour, bitrate) plus photo EXIF (dimensions/size).

## Testing
- `just format-check`, typecheck build, and unit tests all pass.
- UI snapshot test updated for the new field interaction (skipped in CI; runs in the manual snapshot job).