### PR TITLE
feat: adaptive HLS video engine with in-slideshow quality controls

### DIFF
--- a/app/BigImmich/Settings/SettingsView.swift
+++ b/app/BigImmich/Settings/SettingsView.swift
@@ -104,6 +104,9 @@ struct SettingsView: View {
 
     // performance
     @AppStorage("slideshowImageQuality") private var slideshowImageQuality: SlideshowImageQuality = .fullsize
+    @AppStorage("slideshowVideoEngine") private var slideshowVideoEngine: SlideshowVideoEngine = .classic
+    // See SlideshowSettings for why the default is a pinned 1080p rather than Auto.
+    @AppStorage("slideshowVideoQuality") private var slideshowVideoQuality: SlideshowVideoQuality = .fhd1080
     @AppStorage("slideshowPreloadVideos") private var slideshowPreloadVideos: Bool = true
     @AppStorage(ImageDiskCache.thumbnailsEnabledDefaultsKey) private var cacheThumbnails: Bool = true
     @AppStorage(ImageDiskCache.fullSizeEnabledDefaultsKey) private var cacheFullSizeImages: Bool = false
@@ -140,6 +143,13 @@ struct SettingsView: View {
         Binding(
             get: { slideshowShowProgressBar == .always },
             set: { slideshowShowProgressBar = $0 ? .always : .never }
+        )
+    }
+
+    private var hlsEnabled: Binding<Bool> {
+        Binding(
+            get: { slideshowVideoEngine == .hls },
+            set: { slideshowVideoEngine = $0 ? .hls : .classic }
         )
     }
 
@@ -346,38 +356,75 @@ struct SettingsView: View {
     // MARK: - Slideshow
 
     private var slideshowDetail: some View {
-        card {
-            pickerRow("Slide interval", value: $slideshowInterval, options: slideIntervalOptions, first: true)
-            rowDivider
-            pickerRow(
-                "Direction",
-                value: $slideshowDirection,
-                options: [
-                    ("oldest → newest", .oldestToNewest),
-                    ("newest → oldest", .newestToOldest),
-                    ("randomized", .randomized)
-                ]
-            )
-            rowDivider
-            pickerRow(
-                "When an album ends",
-                value: $slideshowOnceEndedAction,
-                options: [
-                    ("stop and show a message", .stopAndNotify),
-                    ("start again", .startAgain),
-                    ("load another album", .loadAnotherAlbum)
-                ]
-            )
-            if slideshowOnceEndedAction == .loadAnotherAlbum {
+        VStack(alignment: .leading, spacing: 20) {
+            sectionHeader("General")
+            card {
+                pickerRow(
+                    "Direction",
+                    value: $slideshowDirection,
+                    options: [
+                        ("oldest → newest", .oldestToNewest),
+                        ("newest → oldest", .newestToOldest),
+                        ("randomized", .randomized)
+                    ],
+                    first: true
+                )
                 rowDivider
                 pickerRow(
-                    "Next album",
-                    value: $slideshowOnceEndedAnotherAlbumSelection,
-                    options: [("older", .older), ("newer", .newer), ("random", .random)]
+                    "When an album ends",
+                    value: $slideshowOnceEndedAction,
+                    options: [
+                        ("stop and show a message", .stopAndNotify),
+                        ("start again", .startAgain),
+                        ("load another album", .loadAnotherAlbum)
+                    ]
                 )
+                if slideshowOnceEndedAction == .loadAnotherAlbum {
+                    rowDivider
+                    pickerRow(
+                        "Next album",
+                        value: $slideshowOnceEndedAnotherAlbumSelection,
+                        options: [("older", .older), ("newer", .newer), ("random", .random)]
+                    )
+                }
+                rowDivider
+                toggleRow("Show progress bar", isOn: showProgressBar)
             }
-            rowDivider
-            toggleRow("Show progress bar", isOn: showProgressBar)
+
+            sectionHeader("Picture")
+            card {
+                pickerRow("Slide interval", value: $slideshowInterval, options: slideIntervalOptions, first: true)
+            }
+
+            sectionHeader("Video")
+            card {
+                toggleRow(
+                    "HLS video player (experimental)",
+                    subtitle: "Adaptive streaming that re-encodes on the fly. Experimental in Immich — "
+                        + "it needs real-time transcoding enabled on your server, and falls back to the "
+                        + "classic player automatically if it isn't available.",
+                    isOn: hlsEnabled,
+                    first: true
+                )
+                if slideshowVideoEngine == .hls {
+                    rowDivider
+                    pickerRow(
+                        "Forced quality",
+                        subtitle: "Auto adapts to bandwidth but cold-starts low and ramps up. Slideshow "
+                            + "clips are short, so pinning a stable, high-enough resolution is recommended "
+                            + "— it starts at full quality instead of ramping (capped to what the server offers).",
+                        value: $slideshowVideoQuality,
+                        options: [
+                            ("Auto (adaptive)", .auto),
+                            ("2160p (4K)", .uhd2160),
+                            ("1440p", .qhd1440),
+                            ("1080p", .fhd1080),
+                            ("720p", .hd720),
+                            ("480p", .sd480)
+                        ]
+                    )
+                }
+            }
         }
     }
 
@@ -487,6 +534,7 @@ struct SettingsView: View {
 
     private var performanceDetail: some View {
         VStack(alignment: .leading, spacing: 20) {
+            sectionHeader("Loading")
             card {
                 pickerRow(
                     "Photo quality",
@@ -553,9 +601,10 @@ struct SettingsView: View {
             } else {
                 VStack(alignment: .leading, spacing: 10) {
                     ForEach(Array(appLog.entries.suffix(20).reversed())) { entry in
-                        DebugLogRow(entry: entry, maxWidth: 900)
+                        DebugLogRow(entry: entry)
                     }
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
     }
@@ -857,7 +906,6 @@ private struct EditableFieldRow: View {
 
 private struct DebugLogRow: View {
     let entry: LogEntry
-    let maxWidth: CGFloat
 
     @FocusState private var focused: Bool
 
@@ -865,7 +913,10 @@ private struct DebugLogRow: View {
         Text("[\(entry.date.formatted(date: .omitted, time: .standard))] \(entry.message)")
             .font(.system(.caption, design: .monospaced))
             .foregroundColor(.red)
-            .frame(maxWidth: maxWidth, alignment: .leading)
+            // Fill the column width so the row spans under the "Clear logs" button — both so it
+            // reads full-width and so an up-press from the top row can reach that button (tvOS
+            // focus is geometric; a narrow left-aligned row has nothing focusable directly above).
+            .frame(maxWidth: .infinity, alignment: .leading)
             .fixedSize(horizontal: false, vertical: true)
             .padding(.horizontal, 12)
             .padding(.vertical, 8)

--- a/app/BigImmich/Settings/Typing.swift
+++ b/app/BigImmich/Settings/Typing.swift
@@ -58,6 +58,81 @@ enum SlideshowShowProgressBar: String, CaseIterable, Identifiable {
     }
 }
 
+/// How video is streamed from Immich.
+///
+/// `classic` uses the legacy progressive `/video/playback` endpoint (a single pre-generated
+/// transcode; works on any server). `hls` uses Immich 3.0+ real-time HLS transcoding
+/// (`/video/stream/main.m3u8`), which re-encodes on the fly to a streamable bitrate and
+/// supports adaptive quality — requires the server to have HLS transcoding enabled.
+enum SlideshowVideoEngine: String, CaseIterable, Identifiable {
+    case classic
+    case hls
+
+    var id: String {
+        rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .classic: "Classic (progressive)"
+        case .hls: "Adaptive (HLS)"
+        }
+    }
+}
+
+/// Preferred HLS quality. `auto` lets the player adapt to bandwidth (may drop under
+/// congestion, recovers automatically). A pinned resolution caps the ladder so playback
+/// stays at that quality and buffers instead of downgrading. The actual variant is resolved
+/// at runtime against what the server advertises in the master playlist.
+enum SlideshowVideoQuality: String, CaseIterable, Identifiable {
+    case auto
+    case uhd2160
+    case qhd1440
+    case fhd1080
+    case hd720
+    case sd480
+
+    var id: String {
+        rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .auto: "Auto (adaptive)"
+        case .uhd2160: "2160p (4K)"
+        case .qhd1440: "1440p"
+        case .fhd1080: "1080p"
+        case .hd720: "720p"
+        case .sd480: "480p"
+        }
+    }
+
+    /// Compact label for the in-slideshow options overlay, so the row stays on one line — just
+    /// "Auto" for the adaptive mode and the bare resolution for the pinned ones.
+    var shortLabel: String {
+        switch self {
+        case .auto: "Auto"
+        case .uhd2160: "2160p"
+        case .qhd1440: "1440p"
+        case .fhd1080: "1080p"
+        case .hd720: "720p"
+        case .sd480: "480p"
+        }
+    }
+
+    /// The pinned rendition height in pixels, or `nil` for `auto`.
+    var maxHeight: Int? {
+        switch self {
+        case .auto: nil
+        case .uhd2160: 2160
+        case .qhd1440: 1440
+        case .fhd1080: 1080
+        case .hd720: 720
+        case .sd480: 480
+        }
+    }
+}
+
 /// Which Immich rendition the slideshow requests for each photo. Smaller renditions
 /// download faster on slow networks; maps to the `size` param on the thumbnail endpoint.
 enum SlideshowImageQuality: String, CaseIterable, Identifiable {
@@ -91,6 +166,8 @@ protocol SlideshowSettingsProtocol {
     var slideshowShowProgressBar: SlideshowShowProgressBar { get set }
     var slideshowImageQuality: SlideshowImageQuality { get set }
     var slideshowPreloadVideos: Bool { get set }
+    var slideshowVideoEngine: SlideshowVideoEngine { get set }
+    var slideshowVideoQuality: SlideshowVideoQuality { get set }
     var slideshowShowVideoStats: Bool { get set }
 }
 
@@ -108,5 +185,14 @@ final class SlideshowSettings: ObservableObject, SlideshowSettingsProtocol {
     @AppStorage("slideshowShowProgressBar") var slideshowShowProgressBar: SlideshowShowProgressBar = .always
     @AppStorage("slideshowImageQuality") var slideshowImageQuality: SlideshowImageQuality = .fullsize
     @AppStorage("slideshowPreloadVideos") var slideshowPreloadVideos: Bool = true
+    /// Defaults to the legacy Classic (progressive) engine — it works on any server. Switching
+    /// to Adaptive (HLS) opts into real-time transcoding + the on-screen quality menu.
+    @AppStorage("slideshowVideoEngine") var slideshowVideoEngine: SlideshowVideoEngine = .classic
+    // Defaults to a pinned 1080p rather than Auto: slideshow clips are often very short, and HLS
+    // ABR cold-starts on the lowest rung and ramps up over several seconds — worsened by real-time
+    // transcoding, where each step up waits on the server to spin up that variant. A short clip
+    // ends before Auto ever climbs, so it looks stuck at low quality. Pinning starts at full
+    // quality immediately (buffering briefly if needed) instead of adapting.
+    @AppStorage("slideshowVideoQuality") var slideshowVideoQuality: SlideshowVideoQuality = .fhd1080
     @AppStorage("slideshowShowVideoStats") var slideshowShowVideoStats: Bool = false
 }

--- a/app/BigImmich/Slideshow/SlideshowView.swift
+++ b/app/BigImmich/Slideshow/SlideshowView.swift
@@ -334,6 +334,10 @@ struct SlideshowView: View {
             if !stats.colorSpace.isEmpty {
                 statLine("Colour", stats.colorSpace)
             }
+            statLine("Engine", viewModel.activeVideoEngine.label)
+            if let variant = stats.variant {
+                statLine("Quality", variant)
+            }
             statLine("Bitrate", SlideshowView.bitrateLabel(stats.indicatedBitrate))
             statLine("Observed", SlideshowView.bitrateLabel(stats.observedBitrate))
             statLine("Buffer", String(format: "%.1fs", stats.bufferedAhead))
@@ -444,6 +448,7 @@ struct SlideshowView: View {
         switch row {
         case .interval: Text("Slideshow interval")
         case .toggleStats: Text("Nerd stats")
+        case .quality: Text("Forced quality")
         }
     }
 
@@ -469,6 +474,17 @@ struct SlideshowView: View {
                     Circle().fill(.white).padding(3),
                     alignment: viewModel.showVideoStats ? .trailing : .leading
                 )
+        case .quality:
+            // Flanked by ‹ › like the interval, faded at the ends of the list (left/right clamp).
+            HStack(spacing: 12) {
+                Text("‹").foregroundColor(.white.opacity(
+                    viewModel.displayVideoQuality == SlideshowVideoQuality.allCases.first ? 0 : 0.4
+                ))
+                Text(viewModel.displayVideoQuality.shortLabel).foregroundColor(.white.opacity(0.85))
+                Text("›").foregroundColor(.white.opacity(
+                    viewModel.displayVideoQuality == SlideshowVideoQuality.allCases.last ? 0 : 0.4
+                ))
+            }
         }
     }
 

--- a/app/BigImmich/Slideshow/SlideshowViewModel.swift
+++ b/app/BigImmich/Slideshow/SlideshowViewModel.swift
@@ -43,6 +43,14 @@ final class SlideshowViewModel {
     /// Observable mirror of the slideshow interval shown live in the options overlay. `settings`
     /// is `@ObservationIgnored`, so the overlay reads this to re-render when the value changes.
     var displayInterval = 5
+    /// Observable mirrors of the video-engine / quality settings, for the same reason as
+    /// `displayInterval`: the options overlay reads these to re-render live.
+    var displayVideoEngine: SlideshowVideoEngine = .classic
+    var displayVideoQuality: SlideshowVideoQuality = .fhd1080
+    /// The engine actually in use after runtime resolution — equals `displayVideoEngine` unless
+    /// HLS was requested but the server couldn't serve it, in which case it falls back to
+    /// `.classic`. Shown in the nerd-stats overlay.
+    var activeVideoEngine: SlideshowVideoEngine = .classic
     /// A short-lived "peek" of the video progress bar while playing (the down button). Ignored
     /// while paused, where the bar is shown permanently.
     var scrubberPeek = false
@@ -79,6 +87,18 @@ final class SlideshowViewModel {
     /// avoid holding several open streams.
     @ObservationIgnored private var prewarmedVideo: (id: AssetID, asset: AVURLAsset)?
 
+    /// The active HLS session (asset it belongs to + server session id), so it can be released
+    /// on the server when we move off the video or exit. `nil` for the classic engine.
+    @ObservationIgnored private var currentHLS: (assetID: AssetID, sessionID: String)?
+
+    /// The resolved HLS stream for the current video, kept so the quality menu can switch
+    /// renditions without a new server round-trip (it reuses the same session's variant URLs).
+    @ObservationIgnored private var currentHLSStream: HLSStream?
+
+    /// Set once we've told the user that HLS was requested but fell back to Classic (e.g. the
+    /// server has real-time transcoding disabled), so the notice shows once, not per video.
+    @ObservationIgnored private var hlsFallbackNotified = false
+
     init(
         initialAlbumID: AlbumID,
         initialAlbumName: AlbumName,
@@ -101,10 +121,9 @@ final class SlideshowViewModel {
             guard let self else { return }
             videoState = state
             // `.buffering`/`.loading` are patient states — we wait for the buffer, never skip.
-            // Only a real failure advances the slideshow.
+            // Only a real failure acts: an HLS failure retries on Classic, otherwise we advance.
             if case let .failed(message) = state {
-                showError(message)
-                Task { await self.moveToNext() }
+                Task { await self.handleVideoFailure(message) }
             }
         }
         videoController.onStatsChange = { [weak self] stats in
@@ -122,6 +141,9 @@ final class SlideshowViewModel {
     private func syncOverlayMirrors() {
         showVideoStats = settings.slideshowShowVideoStats
         displayInterval = settings.slideshowInterval
+        displayVideoEngine = settings.slideshowVideoEngine
+        displayVideoQuality = settings.slideshowVideoQuality
+        activeVideoEngine = settings.slideshowVideoEngine
     }
 
     func stop() {
@@ -453,26 +475,19 @@ final class SlideshowViewModel {
                 startImageTimers()
             }
         } else if asset.assetType == .video {
-            let urlAsset: AVURLAsset
+            let source: VideoSource
             if let prewarmed = prewarmedVideo, prewarmed.id == asset.id {
+                // A prewarmed video is always the classic progressive stream (HLS isn't prewarmed).
                 prewarmedVideo = nil
-                urlAsset = prewarmed.asset
-            } else if let url = try? await immichClient.videoPlaybackURL(assetID: asset.id) {
-                urlAsset = AVURLAsset(url: url)
+                source = VideoSource(asset: prewarmed.asset, engine: .classic, variantLabel: "Classic")
+            } else if let resolved = await makeVideoSource(for: asset) {
+                source = resolved
             } else {
                 showError("loading video failed: failed to construct playback URL")
                 return
             }
 
-            videoController.start(
-                asset: urlAsset,
-                autoplay: slideshowIsRunning,
-                forwardBufferDuration: 30,
-                onEnded: { [weak self] in
-                    Task { await self?.moveToNext() }
-                }
-            )
-            currentPlayer = videoController.player
+            applyVideoSource(source, assetID: asset.id, startAt: 0)
             // A video that loads while the slideshow is paused (e.g. navigated to from a paused
             // asset) shows its progress bar automatically via `showVideoScrubber`.
         }
@@ -503,7 +518,10 @@ final class SlideshowViewModel {
 
         // Warm only the immediate next video, to avoid opening several streams at once.
         // Skippable from Settings if prewarming ever causes trouble on a given setup.
+        // HLS is not prewarmed: warming its master would spin up a second server-side
+        // transcoding session for a video we may never reach.
         if settings.slideshowPreloadVideos,
+           settings.slideshowVideoEngine == .classic,
            let next = upcoming.first, next.asset.assetType == .video
         {
             await prewarmVideo(asset: next.asset)
@@ -527,18 +545,26 @@ final class SlideshowViewModel {
     enum OptionRow: Identifiable, Equatable {
         case interval
         case toggleStats
+        case quality
 
         var id: String {
             switch self {
             case .interval: "interval"
             case .toggleStats: "stats"
+            case .quality: "quality"
             }
         }
     }
 
     var optionsMenuItems: [OptionRow] {
         if currentPlayer != nil {
-            return [.toggleStats]
+            // Video: toggle nerd stats, plus a forced-quality row — but only on the adaptive (HLS)
+            // engine, which is what quality applies to. The engine itself is chosen in Settings.
+            var items: [OptionRow] = [.toggleStats]
+            if displayVideoEngine == .hls {
+                items.insert(.quality, at: 0)
+            }
+            return items
         }
         if currentImage != nil {
             return [.interval, .toggleStats]
@@ -586,23 +612,34 @@ final class SlideshowViewModel {
     /// nerd-stats row flips too. Off-centre touchpad clicks land as a directional press rather than
     /// a select, so honouring left/right here is what makes the toggle reliable to flip.
     private func adjustCurrentOption(_ direction: MoveCommandDirection) {
+        let forward = direction == .right
         switch currentOptionRow() {
         case .interval:
-            let value = displayInterval + (direction == .right ? 1 : -1)
+            let value = displayInterval + (forward ? 1 : -1)
             let clamped = min(max(value, 1), 60)
             settings.slideshowInterval = clamped
             displayInterval = clamped
         case .toggleStats:
             toggleVideoStats()
+        case .quality:
+            cycleQuality(forward: forward, wrap: false)
         case .none:
             break
         }
     }
 
-    /// The select (middle) button flips the nerd-stats toggle.
+    /// The select (middle) button acts on the highlighted row: flips the nerd-stats toggle, or
+    /// steps quality one rung (wrapping past the end). Interval is left/right only.
     func handleSelect() {
-        guard showOptionsMenu, case .toggleStats = currentOptionRow() else { return }
-        toggleVideoStats()
+        guard showOptionsMenu else { return }
+        switch currentOptionRow() {
+        case .toggleStats:
+            toggleVideoStats()
+        case .quality:
+            cycleQuality(forward: true, wrap: true)
+        case .interval, .none:
+            break
+        }
     }
 
     private func toggleVideoStats() {
@@ -611,6 +648,223 @@ final class SlideshowViewModel {
         if showVideoStats {
             loadDetailedAssetIfNeeded()
         }
+    }
+
+    // MARK: - Video engine (Classic / adaptive HLS)
+
+    /// A ready-to-play video: the AVFoundation asset plus how it was resolved (engine, quality
+    /// label, HLS session for cleanup, and any bitrate cap).
+    private struct VideoSource {
+        let asset: AVURLAsset
+        let engine: SlideshowVideoEngine
+        let variantLabel: String
+        var sessionID: String?
+        var maxBitrate: Double = 0
+    }
+
+    /// AVFoundation applies these header fields to every request for the asset — including the
+    /// HLS variant playlists and segments, which is why HLS must authenticate by header (Immich
+    /// advertises those sub-resources as relative URIs, so query-param auth is dropped on them).
+    private static let httpHeaderFieldsOption = "AVURLAssetHTTPHeaderFieldsKey"
+
+    /// Resolves how to play `asset`: HLS when the engine is set to it and the server supports it,
+    /// otherwise the classic progressive stream. A failed HLS resolution (e.g. the server has
+    /// real-time transcoding disabled) transparently falls back to classic.
+    private func makeVideoSource(for asset: AlbumAsset) async -> VideoSource? {
+        if settings.slideshowVideoEngine == .hls,
+           let hls = await makeHLSSource(for: asset)
+        {
+            return hls
+        }
+        guard let url = try? await immichClient.videoPlaybackURL(assetID: asset.id) else {
+            return nil
+        }
+        return VideoSource(asset: AVURLAsset(url: url), engine: .classic, variantLabel: "Classic")
+    }
+
+    private func makeHLSSource(for asset: AlbumAsset) async -> VideoSource? {
+        let stream: HLSStream
+        do {
+            stream = try await immichClient.hlsStream(assetID: asset.id)
+        } catch {
+            // Surface the reason in the on-device debug logs so a fallback can be analysed.
+            AppLog.shared.log(
+                "HLS unavailable for asset \(asset.id.string), falling back to Classic: "
+                    + "\(error)\(Self.hlsFallbackHint(for: error))",
+                level: .error,
+                source: "Video"
+            )
+            return nil
+        }
+        currentHLSStream = stream
+        let options = [Self.httpHeaderFieldsOption: stream.authHeaders]
+
+        // Pinned quality → play one variant playlist directly, so ABR never drops below it.
+        // Auto → hand over the master playlist and let AVFoundation adapt.
+        if let height = settings.slideshowVideoQuality.maxHeight,
+           let variant = stream.variant(forMaxHeight: height)
+        {
+            return VideoSource(
+                asset: AVURLAsset(url: variant.playlistURL, options: options),
+                engine: .hls,
+                variantLabel: "\(variant.heightPixels)p",
+                sessionID: stream.sessionID
+            )
+        }
+        return VideoSource(
+            asset: AVURLAsset(url: stream.masterURL, options: options),
+            engine: .hls,
+            variantLabel: "Auto",
+            sessionID: stream.sessionID
+        )
+    }
+
+    /// An actionable hint for common HLS failures, appended to the debug log.
+    private static func hlsFallbackHint(for error: Error) -> String {
+        switch error {
+        case ImmichAPIError.httpErrorCode(statusCode: 404):
+            " — the server has no stream metadata for this video yet. Run Immich's"
+                + " Administration → Jobs → Extract Metadata (All) to backfill keyframes/packets."
+        case ImmichAPIError.httpErrorCode(statusCode: 400):
+            " — real-time transcoding is disabled on the server (Admin → Settings → Video)."
+        default:
+            ""
+        }
+    }
+
+    /// Publishes a resolved `VideoSource`: records the engine/session, notes any HLS→Classic
+    /// fallback, and starts playback (optionally resuming at `startAt`).
+    private func applyVideoSource(_ source: VideoSource, assetID: AssetID, startAt: Double) {
+        activeVideoEngine = source.engine
+        currentHLS = source.sessionID.map { (assetID, $0) }
+        notifyHLSFallbackIfNeeded(source: source)
+        videoController.start(
+            asset: source.asset,
+            autoplay: slideshowIsRunning,
+            forwardBufferDuration: 30,
+            maxBitrate: source.maxBitrate,
+            startAtSeconds: startAt,
+            variantLabel: source.variantLabel,
+            onEnded: { [weak self] in
+                Task { await self?.moveToNext() }
+            }
+        )
+        currentPlayer = videoController.player
+    }
+
+    /// Once per slideshow session, tells the user when HLS was requested but fell back to
+    /// Classic; the underlying reason is already in the debug logs (see `makeHLSSource`).
+    private func notifyHLSFallbackIfNeeded(source: VideoSource) {
+        guard settings.slideshowVideoEngine == .hls, source.engine == .classic else { return }
+        guard !hlsFallbackNotified else { return }
+        hlsFallbackNotified = true
+        showInformation("Adaptive (HLS) unavailable — using Classic. See Settings → Debug logs.")
+    }
+
+    /// Handles a fatal playback error. When an HLS stream fails mid-playback — e.g. the server
+    /// 404s a variant it advertised, which its alpha real-time transcoder still does — we retry
+    /// the *same* asset once on the classic engine (surfacing the usual blue notice via
+    /// `applyVideoSource`) rather than skipping it. A classic failure, or a second failure after
+    /// falling back, advances to the next asset.
+    private func handleVideoFailure(_ message: String) async {
+        guard activeVideoEngine == .hls,
+              let asset = slideshowAsset?.asset, asset.assetType == .video
+        else {
+            showError(message)
+            await moveToNext()
+            return
+        }
+
+        AppLog.shared.log(
+            "HLS playback failed for asset \(asset.id.string) (\(message)); retrying on Classic.",
+            level: .error,
+            source: "Video"
+        )
+        let resumeAt = videoController.currentSeconds
+        endCurrentHLSSession()
+        guard let url = try? await immichClient.videoPlaybackURL(assetID: asset.id) else {
+            showError(message)
+            await moveToNext()
+            return
+        }
+        applyVideoSource(
+            VideoSource(asset: AVURLAsset(url: url), engine: .classic, variantLabel: "Classic"),
+            assetID: asset.id,
+            startAt: resumeAt
+        )
+    }
+
+    /// Releases the current HLS transcoding session on the server (best-effort), so it stops
+    /// transcoding as soon as we leave the video.
+    private func endCurrentHLSSession() {
+        currentHLSStream = nil
+        guard let current = currentHLS else { return }
+        currentHLS = nil
+        let client = immichClient
+        Task { await client.endHLSSession(assetID: current.assetID, sessionID: current.sessionID) }
+    }
+
+    /// The quality values the Quality row cycles through — the full fixed set (Auto, then tallest
+    /// to shortest), matching the Settings picker. A pinned height the server doesn't advertise
+    /// resolves to the nearest available rung at play time (see `HLSStream.variant(forMaxHeight:)`).
+    var qualityChoices: [SlideshowVideoQuality] {
+        SlideshowVideoQuality.allCases
+    }
+
+    /// Steps the pinned quality through `qualityChoices` and applies it in place when a live HLS
+    /// stream is playing (otherwise it just persists for the next HLS video).
+    private func cycleQuality(forward: Bool, wrap: Bool) {
+        let choices = qualityChoices
+        guard !choices.isEmpty else { return }
+        let current = choices.firstIndex(of: displayVideoQuality) ?? 0
+        let next: Int = if wrap {
+            forward
+                ? (current + 1) % choices.count
+                : (current - 1 + choices.count) % choices.count
+        } else {
+            forward ? min(current + 1, choices.count - 1) : max(current - 1, 0)
+        }
+        let chosen = choices[next]
+        guard chosen != displayVideoQuality else { return }
+        settings.slideshowVideoQuality = chosen
+        displayVideoQuality = chosen
+        if currentHLSStream != nil {
+            reloadCurrentVideoQuality(chosen)
+        }
+    }
+
+    /// Switches the playing video to `quality` in place, reusing the current HLS session's variant
+    /// URLs and resuming from the current position — no extra server round-trip.
+    private func reloadCurrentVideoQuality(_ quality: SlideshowVideoQuality) {
+        guard let stream = currentHLSStream,
+              let asset = slideshowAsset?.asset, asset.assetType == .video
+        else { return }
+
+        let resumeAt = videoController.currentSeconds
+        let options = [Self.httpHeaderFieldsOption: stream.authHeaders]
+
+        let url: URL
+        let label: String
+        if let height = quality.maxHeight, let variant = stream.variant(forMaxHeight: height) {
+            url = variant.playlistURL
+            label = "\(variant.heightPixels)p"
+        } else {
+            url = stream.masterURL
+            label = "Auto"
+        }
+
+        videoController.start(
+            asset: AVURLAsset(url: url, options: options),
+            autoplay: slideshowIsRunning,
+            forwardBufferDuration: 30,
+            startAtSeconds: resumeAt,
+            variantLabel: label,
+            onEnded: { [weak self] in
+                Task { await self?.moveToNext() }
+            }
+        )
+        currentPlayer = videoController.player
+        activeVideoEngine = .hls
     }
 
     /// Warms the next video's connection and initial data so playback starts sooner when we
@@ -670,6 +924,7 @@ final class SlideshowViewModel {
     private func stopCurrentPlayer() {
         videoController.stop()
         currentPlayer = nil
+        endCurrentHLSSession()
     }
 
     private func moveToNext() async {

--- a/app/BigImmichTests/HLSPlaylistParserTests.swift
+++ b/app/BigImmichTests/HLSPlaylistParserTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import ImmichAPI
+import Testing
+
+struct HLSPlaylistParserTests {
+    private let masterURL = URL(
+        string: "https://immich.test/api/assets/asset-1/video/stream/main.m3u8"
+    )!
+
+    private let playlist = """
+    #EXTM3U
+    #EXT-X-VERSION:7
+    #EXT-X-INDEPENDENT-SEGMENTS
+    #EXT-X-STREAM-INF:BANDWIDTH=10800000,RESOLUTION=1920x1080,CODECS="avc1.640028,mp4a.40.2",VIDEO-RANGE=SDR,FRAME-RATE=29.970
+    sess-abc/8/playlist.m3u8
+    #EXT-X-STREAM-INF:BANDWIDTH=6750000,RESOLUTION=1280x720,CODECS="avc1.64001f,mp4a.40.2",VIDEO-RANGE=SDR,FRAME-RATE=29.970
+    sess-abc/5/playlist.m3u8
+
+    """
+
+    @Test func parsesEveryVariant() {
+        let variants = HLSPlaylistParser.parseVariants(playlist: playlist, masterURL: masterURL)
+        #expect(variants.count == 2)
+        #expect(variants[0].heightPixels == 1080)
+        #expect(variants[0].widthPixels == 1920)
+        #expect(variants[0].bandwidth == 10_800_000)
+        #expect(variants[0].index == 8)
+        #expect(variants[1].heightPixels == 720)
+        #expect(variants[1].index == 5)
+    }
+
+    @Test func resolvesRelativeURIsAgainstTheMaster() {
+        let variants = HLSPlaylistParser.parseVariants(playlist: playlist, masterURL: masterURL)
+        #expect(
+            variants[0].playlistURL.absoluteString
+                == "https://immich.test/api/assets/asset-1/video/stream/sess-abc/8/playlist.m3u8"
+        )
+    }
+
+    @Test func extractsSessionIDFromVariantPath() {
+        #expect(
+            HLSPlaylistParser.sessionID(fromVariantURI: "sess-abc/8/playlist.m3u8") == "sess-abc"
+        )
+        #expect(
+            HLSPlaylistParser
+                .sessionID(fromVariantURI: "/api/assets/x/video/stream/sess-xyz/3/playlist.m3u8") == "sess-xyz"
+        )
+    }
+
+    @Test func ignoresPlaylistsWithoutVariants() {
+        let empty = "#EXTM3U\n#EXT-X-VERSION:7\n"
+        #expect(HLSPlaylistParser.parseVariants(playlist: empty, masterURL: masterURL).isEmpty)
+    }
+
+    @Test func pinnedQualityPicksTallestAtOrBelowTarget() {
+        let stream = makeStream()
+        #expect(stream.variant(forMaxHeight: 1080)?.heightPixels == 1080)
+        #expect(stream.variant(forMaxHeight: 900)?.heightPixels == 720)
+        #expect(stream.variant(forMaxHeight: 2160)?.heightPixels == 1080)
+    }
+
+    @Test func pinnedQualityFallsBackToShortestWhenAllAreTaller() {
+        let stream = makeStream()
+        #expect(stream.variant(forMaxHeight: 480)?.heightPixels == 720)
+    }
+
+    @Test func bestVariantIsTheTallest() {
+        #expect(makeStream().bestVariant?.heightPixels == 1080)
+    }
+
+    private func makeStream() -> HLSStream {
+        HLSStream(
+            sessionID: "sess-abc",
+            masterURL: masterURL,
+            authHeaders: ["x-api-key": "k"],
+            variants: HLSPlaylistParser.parseVariants(playlist: playlist, masterURL: masterURL)
+        )
+    }
+}

--- a/app/BigImmichTests/Slideshow/Fakers.swift
+++ b/app/BigImmichTests/Slideshow/Fakers.swift
@@ -70,6 +70,8 @@ struct FakeSettings: SlideshowSettingsProtocol {
     var slideshowShowProgressBar: SlideshowShowProgressBar = .always
     var slideshowImageQuality: SlideshowImageQuality = .fullsize
     var slideshowPreloadVideos: Bool = true
+    var slideshowVideoEngine: SlideshowVideoEngine = .classic
+    var slideshowVideoQuality: SlideshowVideoQuality = .auto
     var slideshowShowVideoStats: Bool = false
 
     init(
@@ -133,4 +135,11 @@ class FakeImmichClient: ImmichClientProtocol {
     func videoPlaybackURL(assetID: AssetID) async throws -> URL {
         URL(string: "https://example.test/\(assetID.string)/video")!
     }
+
+    func hlsStream(assetID: AssetID) async throws -> HLSStream {
+        let master = URL(string: "https://example.test/api/assets/\(assetID.string)/video/stream/main.m3u8")!
+        return HLSStream(sessionID: "test-session", masterURL: master, authHeaders: [:], variants: [])
+    }
+
+    func endHLSSession(assetID _: AssetID, sessionID _: String) async {}
 }

--- a/app/ImmichAPI/HLSStream.swift
+++ b/app/ImmichAPI/HLSStream.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// One quality rendition advertised by an HLS master playlist.
+public struct HLSVariant: Sendable, Equatable {
+    /// The variant index in the server's ladder (the `{variantIndex}` path segment).
+    public let index: Int
+    public let widthPixels: Int
+    public let heightPixels: Int
+    /// Advertised peak bitrate in bits/second.
+    public let bandwidth: Int
+    /// Absolute URL of this variant's media playlist.
+    public let playlistURL: URL
+
+    public init(index: Int, widthPixels: Int, heightPixels: Int, bandwidth: Int, playlistURL: URL) {
+        self.index = index
+        self.widthPixels = widthPixels
+        self.heightPixels = heightPixels
+        self.bandwidth = bandwidth
+        self.playlistURL = playlistURL
+    }
+}
+
+/// A resolved HLS streaming session for one asset: the master playlist to hand AVFoundation for
+/// adaptive (Auto) playback, the individual variants for pinned playback / the quality menu, and
+/// the auth headers that must ride along on every request.
+public struct HLSStream: Sendable {
+    public let sessionID: String
+    public let masterURL: URL
+    public let authHeaders: [String: String]
+    public let variants: [HLSVariant]
+
+    public init(sessionID: String, masterURL: URL, authHeaders: [String: String], variants: [HLSVariant]) {
+        self.sessionID = sessionID
+        self.masterURL = masterURL
+        self.authHeaders = authHeaders
+        self.variants = variants
+    }
+
+    /// The variant whose height best matches a pinned target: the tallest rendition no taller
+    /// than `height`, or — if every rendition is taller — the shortest available. `nil` when
+    /// there are no variants.
+    public func variant(forMaxHeight height: Int) -> HLSVariant? {
+        guard !variants.isEmpty else { return nil }
+        let atOrBelow = variants.filter { $0.heightPixels <= height }
+        if let best = atOrBelow.max(by: { $0.heightPixels < $1.heightPixels }) {
+            return best
+        }
+        return variants.min(by: { $0.heightPixels < $1.heightPixels })
+    }
+
+    /// The highest-resolution variant, for a "pin to best" preference.
+    public var bestVariant: HLSVariant? {
+        variants.max(by: { $0.heightPixels < $1.heightPixels })
+    }
+}
+
+/// Parses an HLS master playlist body into variants. Pure and side-effect free so it can be
+/// unit-tested against captured playlist text.
+///
+/// Immich advertises each variant as a *relative* URI of the form
+/// `{sessionId}/{variantIndex}/playlist.m3u8`, so URIs are resolved against `masterURL` and the
+/// session id / variant index are taken from the URI's path components.
+public enum HLSPlaylistParser {
+    public static func parseVariants(playlist: String, masterURL: URL) -> [HLSVariant] {
+        let lines = playlist.split(whereSeparator: \.isNewline).map { $0.trimmingCharacters(in: .whitespaces) }
+        var variants: [HLSVariant] = []
+
+        var index = 0
+        while index < lines.count {
+            defer { index += 1 }
+            let line = lines[index]
+            guard line.hasPrefix("#EXT-X-STREAM-INF:") else { continue }
+
+            // The URI is the next line that is neither blank nor a tag.
+            var uriLine: String?
+            var lookahead = index + 1
+            while lookahead < lines.count {
+                let candidate = lines[lookahead]
+                if !candidate.isEmpty, !candidate.hasPrefix("#") {
+                    uriLine = candidate
+                    break
+                }
+                lookahead += 1
+            }
+            guard let uri = uriLine,
+                  let playlistURL = URL(string: uri, relativeTo: masterURL)?.absoluteURL
+            else { continue }
+
+            let attrs = parseAttributes(line.dropFirst("#EXT-X-STREAM-INF:".count).description)
+            let (width, height) = parseResolution(attrs["RESOLUTION"])
+            let bandwidth = Int(attrs["BANDWIDTH"] ?? "") ?? 0
+            let variantIndex = variantIndex(from: uri) ?? variants.count
+
+            variants.append(
+                HLSVariant(
+                    index: variantIndex,
+                    widthPixels: width,
+                    heightPixels: height,
+                    bandwidth: bandwidth,
+                    playlistURL: playlistURL
+                )
+            )
+        }
+        return variants
+    }
+
+    /// The session id from a variant URI `{sessionId}/{variantIndex}/playlist.m3u8`.
+    public static func sessionID(fromVariantURI uri: String) -> String? {
+        let parts = uri.split(separator: "/")
+        guard parts.count >= 3 else { return nil }
+        return String(parts[parts.count - 3])
+    }
+
+    private static func variantIndex(from uri: String) -> Int? {
+        let parts = uri.split(separator: "/")
+        guard parts.count >= 2 else { return nil }
+        return Int(parts[parts.count - 2])
+    }
+
+    /// Splits a comma-separated attribute list, honoring quoted values that contain commas
+    /// (e.g. `CODECS="avc1.640028,mp4a.40.2"`).
+    private static func parseAttributes(_ text: String) -> [String: String] {
+        var result: [String: String] = [:]
+        var current = ""
+        var inQuotes = false
+        var fields: [String] = []
+        for char in text {
+            if char == "\"" {
+                inQuotes.toggle()
+                current.append(char)
+            } else if char == ",", !inQuotes {
+                fields.append(current)
+                current = ""
+            } else {
+                current.append(char)
+            }
+        }
+        if !current.isEmpty {
+            fields.append(current)
+        }
+
+        for field in fields {
+            guard let eq = field.firstIndex(of: "=") else { continue }
+            let key = field[..<eq].trimmingCharacters(in: .whitespaces)
+            var value = field[field.index(after: eq)...].trimmingCharacters(in: .whitespaces)
+            if value.hasPrefix("\""), value.hasSuffix("\""), value.count >= 2 {
+                value = String(value.dropFirst().dropLast())
+            }
+            result[key] = value
+        }
+        return result
+    }
+
+    private static func parseResolution(_ value: String?) -> (Int, Int) {
+        guard let value else { return (0, 0) }
+        let parts = value.lowercased().split(separator: "x")
+        guard parts.count == 2, let width = Int(parts[0]), let height = Int(parts[1]) else { return (0, 0) }
+        return (width, height)
+    }
+}

--- a/app/ImmichAPI/ImmichAPI.swift
+++ b/app/ImmichAPI/ImmichAPI.swift
@@ -219,6 +219,22 @@ class ImmichAPIClient {
         }
     }
 
+    /// Issues a request and discards the body (used for DELETE, which returns 204 No Content).
+    func send(
+        httpMethod: String,
+        path: String,
+        queryParams: [String: String]?,
+        headers: [String: String]?
+    ) async throws {
+        _ = try await request(
+            httpMethod: httpMethod,
+            path: path,
+            queryParams: queryParams,
+            headers: headers,
+            jsonPayload: nil
+        )
+    }
+
     func loadMedia(
         httpMethod: String,
         path: String,
@@ -523,5 +539,42 @@ public actor ImmichAPI {
         guard let playbackUrl else { throw ImmichAPIError.badUrl }
 
         return playbackUrl
+    }
+
+    /// Issues a request with header auth and no response body (e.g. DELETE). Retries once on 401.
+    public func sendRequest(httpMethod: String, path: String) async throws {
+        try await withAuthRetry { client in
+            try await client.send(
+                httpMethod: httpMethod,
+                path: path,
+                queryParams: nil,
+                headers: findAuthHeaders()
+            )
+        }
+    }
+
+    /// Auth headers for media requests (`x-api-key` or the session-token header).
+    ///
+    /// HLS needs these because AVFoundation fetches the variant playlists and segments itself,
+    /// and Immich advertises them as *relative* URIs — so query-param auth on the master URL is
+    /// dropped on those sub-requests. Header auth (attached to the whole `AVURLAsset`) is the
+    /// only form that reaches every request.
+    public func mediaAuthHeaders() async throws -> [String: String] {
+        try await findAuthHeaders()
+    }
+
+    /// Builds a media URL with **no auth in the query** (auth travels in headers instead).
+    /// Used for the HLS master playlist, whose relative sub-URIs can't carry query auth.
+    public func mediaURL(path: String, queryParams: [String: String]?) throws -> URL {
+        guard let config = getConfig() else {
+            throw ImmichAPIError.missingConfig
+        }
+        guard let url = ImmichAPIClient(
+            baseURL: config.baseURL,
+            executor: executor
+        ).getUrl(path: path, queryParams: queryParams) else {
+            throw ImmichAPIError.badUrl
+        }
+        return url
     }
 }

--- a/app/ImmichAPI/ImmichClient.swift
+++ b/app/ImmichAPI/ImmichClient.swift
@@ -44,6 +44,8 @@ public protocol ImmichClientProtocol {
     func loadThumbnail(assetID: AssetID, size: ThumbnailSize, retries: Int) async throws -> Data
     func thumbnailURL(assetID: AssetID, size: ThumbnailSize) async throws -> URL
     func videoPlaybackURL(assetID: AssetID) async throws -> URL
+    func hlsStream(assetID: AssetID) async throws -> HLSStream
+    func endHLSSession(assetID: AssetID, sessionID: String) async
 }
 
 func joinAlbums(order: AlbumsOrder, albumLists: [[AlbumSummary]]) -> [AlbumSummary] {
@@ -125,6 +127,39 @@ public class ImmichClient: ImmichClientProtocol {
             path: "/api/assets/\(assetID.string)/video/playback",
             queryParams: nil
         )
+    }
+
+    /// Resolves an HLS streaming session for `assetID`: fetches the master playlist (which
+    /// requires the server to have real-time transcoding enabled — otherwise this throws and the
+    /// caller falls back to `videoPlaybackURL`), parses its variants, and returns everything the
+    /// player needs, including the header auth that HLS sub-requests require.
+    public func hlsStream(assetID: AssetID) async throws -> HLSStream {
+        let path = "/api/assets/\(assetID.string)/video/stream/main.m3u8"
+        let data = try await ImmichAPI.shared.loadMedia(path: path, queryParams: nil)
+        let playlist = String(decoding: data, as: UTF8.self)
+        let masterURL = try await ImmichAPI.shared.mediaURL(path: path, queryParams: nil)
+        let headers = try await ImmichAPI.shared.mediaAuthHeaders()
+
+        let variants = HLSPlaylistParser.parseVariants(playlist: playlist, masterURL: masterURL)
+        guard let firstVariant = variants.first,
+              let sessionID = HLSPlaylistParser.sessionID(fromVariantURI: firstVariant.playlistURL.path)
+        else {
+            throw ImmichAPIError.badResponse
+        }
+
+        return HLSStream(
+            sessionID: sessionID,
+            masterURL: masterURL,
+            authHeaders: headers,
+            variants: variants
+        )
+    }
+
+    /// Releases the server-side transcoding session. Best-effort — failures are ignored since the
+    /// server also times sessions out on its own.
+    public func endHLSSession(assetID: AssetID, sessionID: String) async {
+        let path = "/api/assets/\(assetID.string)/video/stream/\(sessionID)"
+        try? await ImmichAPI.shared.sendRequest(httpMethod: "DELETE", path: path)
     }
 
     public func getServerVersion() async throws -> ServerVersion {


### PR DESCRIPTION
## Summary

Adds an opt-in, **experimental adaptive (HLS)** video engine using Immich 3.0+ real-time transcoding. The classic progressive player stays the default; HLS is chosen in Settings and falls back to classic automatically whenever it can't play.

Validated end-to-end against a live Immich 3.0.3 server (real-time transcoding on, GPU-accelerated — top 2160p rung transcodes at ~6.8× realtime).

## What's included

**Streaming engine**
- `HLSStream` model + master-playlist parser; `ImmichClient.hlsStream()` / `endHLSSession()`.
- Header-auth plumbing — Immich advertises variants/segments as relative URIs, so auth must ride in request headers (via `AVURLAssetHTTPHeaderFieldsKey`), not the query string.
- Server transcode sessions are released on every transition and on exit.

**Playback & fallback**
- Per-video HLS resolution with transparent fallback to the classic player when the server can't serve HLS (400 = transcoding disabled, 404 = run Extract Metadata) **or** a stream fails mid-playback — surfaced via the usual blue notice, with the reason in the debug log.
- Default quality is a **pinned 1080p** rather than Auto: slideshow clips are short and HLS ABR cold-starts low and ramps slowly (worse under real-time transcoding), so pinning starts at full quality immediately.

**UI**
- Settings → Slideshow → Video: **HLS video player (experimental)** toggle + **Forced quality** picker. Slideshow settings reorganized into **General / Picture / Video**; Performance's first section named **Loading**.
- In-slideshow options overlay: **Forced quality** row (HLS only), stepped with the remote like the interval row.
- Debug-log rows now fill their column width, which also lets remote focus move from the log list up to the **Clear logs** button.

## Test plan
- [x] `just build` — succeeds
- [x] `just test-unit` — passes, incl. 7 new `HLSPlaylistParserTests`
- [x] `just format` — clean
- [x] Server pipeline verified via curl (master → variant → segment, header auth; 401 without auth)